### PR TITLE
Add more package managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,15 @@ trouxa -m pacman -p https://pastebin.com/raw/ysHUVswx
 
 
 ## Package managers supported
-- pacman
-- yay
-- apt
 - apk
+- apt
+- aptitude
+- dnf
+- pacman
+- snap
+- yay
+- yum
+- zypper
 
 ## How to install
 

--- a/internal/commander/commander.go
+++ b/internal/commander/commander.go
@@ -6,8 +6,13 @@ import (
 	"github.com/Bainoware/trouxa/internal/manager"
 	"github.com/Bainoware/trouxa/internal/manager/apk"
 	"github.com/Bainoware/trouxa/internal/manager/apt"
+	"github.com/Bainoware/trouxa/internal/manager/aptitude"
+	"github.com/Bainoware/trouxa/internal/manager/dnf"
 	"github.com/Bainoware/trouxa/internal/manager/pacman"
+	"github.com/Bainoware/trouxa/internal/manager/snap"
 	"github.com/Bainoware/trouxa/internal/manager/yay"
+	"github.com/Bainoware/trouxa/internal/manager/yum"
+	"github.com/Bainoware/trouxa/internal/manager/zypper"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -29,10 +34,20 @@ func FromName(name string) Commander {
 		return new(apt.Commander)
 	case "apk":
 		return new(apk.Commander)
+	case "aptitude":
+		return new(aptitude.Commander)
+	case "dnf":
+		return new(dnf.Commander)
 	case "pacman":
 		return new(pacman.Commander)
+	case "snap":
+		return new(snap.Commander)
 	case "yay":
 		return new(yay.Commander)
+	case "yum":
+		return new(yum.Commander)
+	case "zypper":
+		return new(zypper.Commander)
 	default:
 		return nil
 	}

--- a/internal/manager/aptitude/aptitude.go
+++ b/internal/manager/aptitude/aptitude.go
@@ -1,0 +1,18 @@
+package aptitude
+
+import (
+	"os/exec"
+)
+
+type Commander struct {
+}
+
+// BuildInstallCommand create the installation command to aptitude
+func (a *Commander) BuildInstallCommand(name string) *exec.Cmd {
+	return exec.Command("aptitude", "install", "-y", name)
+}
+
+// BuildUninstallCommand create the uninstallation command to aptitude
+func (a *Commander) BuildUninstallCommand(name string) *exec.Cmd {
+	return exec.Command("aptitude", "remove", "-y", name)
+}

--- a/internal/manager/dnf/dnf.go
+++ b/internal/manager/dnf/dnf.go
@@ -1,0 +1,18 @@
+package dnf
+
+import (
+	"os/exec"
+)
+
+type Commander struct {
+}
+
+// BuildInstallCommand create the installation command to dnf
+func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
+	return exec.Command("dnf", "install", "-y", name)
+}
+
+// BuildUninstallCommand create the uninstallation command to dnf
+func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
+	return exec.Command("dnf", "remove", "-y", name)
+}

--- a/internal/manager/snap/snap.go
+++ b/internal/manager/snap/snap.go
@@ -1,0 +1,18 @@
+package snap
+
+import (
+	"os/exec"
+)
+
+type Commander struct {
+}
+
+// BuildInstallCommand create the installation command to snap
+func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
+	return exec.Command("snap", "install", name)
+}
+
+// BuildUninstallCommand create the uninstallation command to snap
+func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
+	return exec.Command("snap", "remove", name)
+}

--- a/internal/manager/yum/yum.go
+++ b/internal/manager/yum/yum.go
@@ -1,0 +1,18 @@
+package yum
+
+import (
+	"os/exec"
+)
+
+type Commander struct {
+}
+
+// BuildInstallCommand create the installation command to yum
+func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
+	return exec.Command("yum", "install", "-y", name)
+}
+
+// BuildUninstallCommand create the uninstallation command to yum
+func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
+	return exec.Command("yum", "remove", "-y", name)
+}

--- a/internal/manager/zypper/zypper.go
+++ b/internal/manager/zypper/zypper.go
@@ -1,0 +1,18 @@
+package zypper
+
+import (
+	"os/exec"
+)
+
+type Commander struct {
+}
+
+// BuildInstallCommand create the installation command to zypper
+func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
+	return exec.Command("zypper", "install", "-y", name)
+}
+
+// BuildUninstallCommand create the uninstallation command to zypper
+func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
+	return exec.Command("zypper", "remove", "-y", name)
+}


### PR DESCRIPTION
This pull request adds implementations for the following package managers:
- aptitude
- dnf
- snap
- yum
- zypper

The following issue is related to this PR: https://github.com/Baianoware/trouxa/issues/6

Validation

All build and validation steps conducted on an Ubuntu 22.04 host

build binary
```
$ cd ~/trouxa
$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src golang:1.18 /bin/bash
root@08bc8835092f:/src# make build
root@08bc8835092f:/src# exit
```

populate packages
```
cat <<EOF > packages.txt
vim
nano
EOF
```

Test binary with package managers

aptitude
```
$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src debian:11.5 /bin/bash

root@011b675d354a:/src# apt-get update && apt-get install -y aptitude
root@011b675d354a:/src# ./build/trouxa -m aptitude -p packages.txt
INFO[0000] Trying to install the package:  vim
The following NEW packages will be installed:
  vim vim-common{a} vim-runtime{a} xxd{a}
0 packages upgraded, 4 newly installed, 0 to remove and 0 not upgraded.
Need to get 8138 kB of archives. After unpacking 36.9 MB will be used.
Get: 1 http://deb.debian.org/debian bullseye/main amd64 xxd amd64 2:8.2.2434-3+deb11u1 [192 kB]
Get: 2 http://deb.debian.org/debian bullseye/main amd64 vim-common all 2:8.2.2434-3+deb11u1 [226 kB]
Get: 3 http://deb.debian.org/debian bullseye/main amd64 vim-runtime all 2:8.2.2434-3+deb11u1 [6226 kB]
Get: 4 http://deb.debian.org/debian bullseye/main amd64 vim amd64 2:8.2.2434-3+deb11u1 [1494 kB]
Fetched 8138 kB in 7s (1239 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package xxd.
(Reading database ... 9185 files and directories currently installed.)
Preparing to unpack .../xxd_2%3a8.2.2434-3+deb11u1_amd64.deb ...
Unpacking xxd (2:8.2.2434-3+deb11u1) ...
Selecting previously unselected package vim-common.
Preparing to unpack .../vim-common_2%3a8.2.2434-3+deb11u1_all.deb ...
Unpacking vim-common (2:8.2.2434-3+deb11u1) ...
Selecting previously unselected package vim-runtime.
Preparing to unpack .../vim-runtime_2%3a8.2.2434-3+deb11u1_all.deb ...
Adding 'diversion of /usr/share/vim/vim82/doc/help.txt to /usr/share/vim/vim82/doc/help.txt.vim-tiny by vim-runtime'
Adding 'diversion of /usr/share/vim/vim82/doc/tags to /usr/share/vim/vim82/doc/tags.vim-tiny by vim-runtime'
Unpacking vim-runtime (2:8.2.2434-3+deb11u1) ...
Selecting previously unselected package vim.
Preparing to unpack .../vim_2%3a8.2.2434-3+deb11u1_amd64.deb ...
Unpacking vim (2:8.2.2434-3+deb11u1) ...
Setting up xxd (2:8.2.2434-3+deb11u1) ...
Setting up vim-common (2:8.2.2434-3+deb11u1) ...
Setting up vim-runtime (2:8.2.2434-3+deb11u1) ...
Setting up vim (2:8.2.2434-3+deb11u1) ...
update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/vim (vim) in auto mode
update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/vimdiff (vimdiff) in auto mode
update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/rvim (rvim) in auto mode
update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/rview (rview) in auto mode
update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/vi (vi) in auto mode
update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/view (view) in auto mode
update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/ex (ex) in auto mode
update-alternatives: using /usr/bin/vim.basic to provide /usr/bin/editor (editor) in auto mode

INFO[0011] Package installed:  vim
INFO[0011] Successful installation of:  vim
INFO[0011] Trying to install the package:  nano
The following NEW packages will be installed:
  nano
0 packages upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 656 kB of archives. After unpacking 2591 kB will be used.
Get: 1 http://deb.debian.org/debian bullseye/main amd64 nano amd64 5.4-2+deb11u1 [656 kB]
Fetched 656 kB in 6s (104 kB/s)
debconf: delaying package configuration, since apt-utils is not installed
Selecting previously unselected package nano.
(Reading database ... 11161 files and directories currently installed.)
Preparing to unpack .../nano_5.4-2+deb11u1_amd64.deb ...
Unpacking nano (5.4-2+deb11u1) ...
Setting up nano (5.4-2+deb11u1) ...
update-alternatives: using /bin/nano to provide /usr/bin/editor (editor) in auto mode
update-alternatives: using /bin/nano to provide /usr/bin/pico (pico) in auto mode

INFO[0020] Package installed:  nano
INFO[0020] Successful installation of:  nano
INFO[0020] Trying to install the package:
Couldn't find any package whose name is "", but there are 78174 packages which contain "" in their name:
  (too many to show, the limit is 40)
Unable to apply some actions, aborting
ERRO[0022] Could not install the package.                error="exit status 255"
INFO[0022] Fail to install:
INFO[0022] Total success package's installation: [vim nano]
INFO[0022] Total fail package's installation: []
```

dnf
```
$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src rockylinux:9.0 /bin/bash

[root@38b0e10dcc4f /src]# ./build/trouxa -m dnf -p packages.txt
INFO[0000] Trying to install the package:  vim
Rocky Linux 9 - BaseOS                                                                                                                                                                              4.5 MB/s | 1.7 MB     00:00
Rocky Linux 9 - AppStream                                                                                                                                                                           1.8 MB/s | 6.0 MB     00:03
Rocky Linux 9 - Extras                                                                                                                                                                              5.3 kB/s | 6.6 kB     00:01
Dependencies resolved.
====================================================================================================================================================================================================================================
 Package                                                 Architecture                                    Version                                                           Repository                                          Size
====================================================================================================================================================================================================================================
Installing:
 vim-enhanced                                            x86_64                                          2:8.2.2637-16.el9_0.3                                             appstream                                          1.8 M
Installing dependencies:
 gpm-libs                                                x86_64                                          1.20.7-29.el9                                                     appstream                                           20 k
 vim-common                                              x86_64                                          2:8.2.2637-16.el9_0.3                                             appstream                                          6.6 M
 vim-filesystem                                          noarch                                          2:8.2.2637-16.el9_0.3                                             baseos                                              20 k
 which                                                   x86_64                                          2.21-27.el9                                                       baseos                                              41 k

Transaction Summary
====================================================================================================================================================================================================================================
Install  5 Packages

Total download size: 8.4 M
Installed size: 34 M
Downloading Packages:
(1/5): which-2.21-27.el9.x86_64.rpm                                                                                                                                                                 171 kB/s |  41 kB     00:00
(2/5): vim-filesystem-8.2.2637-16.el9_0.3.noarch.rpm                                                                                                                                                 71 kB/s |  20 kB     00:00
(3/5): gpm-libs-1.20.7-29.el9.x86_64.rpm                                                                                                                                                             44 kB/s |  20 kB     00:00
(4/5): vim-enhanced-8.2.2637-16.el9_0.3.x86_64.rpm                                                                                                                                                  1.6 MB/s | 1.8 MB     00:01
(5/5): vim-common-8.2.2637-16.el9_0.3.x86_64.rpm                                                                                                                                                    6.2 MB/s | 6.6 MB     00:01
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                                               5.1 MB/s | 8.4 MB     00:01
Rocky Linux 9 - BaseOS                                                                                                                                                                              1.7 MB/s | 1.7 kB     00:00
Importing GPG key 0x350D275D:
 Userid     : "Rocky Enterprise Software Foundation - Release key 2022 <releng@rockylinux.org>"
 Fingerprint: 21CB 256A E16F C54C 6E65 2949 702D 426D 350D 275D
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
Key imported successfully
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                            1/1
  Installing       : gpm-libs-1.20.7-29.el9.x86_64                                                                                                                                                                              1/5
  Installing       : vim-filesystem-2:8.2.2637-16.el9_0.3.noarch                                                                                                                                                                2/5
  Installing       : vim-common-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                    3/5
  Installing       : which-2.21-27.el9.x86_64                                                                                                                                                                                   4/5
  Installing       : vim-enhanced-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                  5/5
  Running scriptlet: vim-enhanced-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                  5/5
  Verifying        : which-2.21-27.el9.x86_64                                                                                                                                                                                   1/5
  Verifying        : vim-filesystem-2:8.2.2637-16.el9_0.3.noarch                                                                                                                                                                2/5
  Verifying        : vim-enhanced-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                  3/5
  Verifying        : vim-common-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                    4/5
  Verifying        : gpm-libs-1.20.7-29.el9.x86_64                                                                                                                                                                              5/5

Installed:
  gpm-libs-1.20.7-29.el9.x86_64          vim-common-2:8.2.2637-16.el9_0.3.x86_64          vim-enhanced-2:8.2.2637-16.el9_0.3.x86_64          vim-filesystem-2:8.2.2637-16.el9_0.3.noarch          which-2.21-27.el9.x86_64

Complete!
INFO[0016] Package installed:  vim
INFO[0016] Successful installation of:  vim
INFO[0016] Trying to install the package:  nano
Last metadata expiration check: 0:00:09 ago on Fri Sep 30 19:52:02 2022.
Dependencies resolved.
====================================================================================================================================================================================================================================
 Package                                             Architecture                                          Version                                                      Repository                                             Size
====================================================================================================================================================================================================================================
Installing:
 nano                                                x86_64                                                5.6.1-5.el9                                                  baseos                                                694 k

Transaction Summary
====================================================================================================================================================================================================================================
Install  1 Package

Total download size: 694 k
Installed size: 2.7 M
Downloading Packages:
nano-5.6.1-5.el9.x86_64.rpm                                                                                                                                                                         1.0 MB/s | 694 kB     00:00
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                                               809 kB/s | 694 kB     00:00
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                            1/1
  Installing       : nano-5.6.1-5.el9.x86_64                                                                                                                                                                                    1/1
  Running scriptlet: nano-5.6.1-5.el9.x86_64                                                                                                                                                                                    1/1
  Verifying        : nano-5.6.1-5.el9.x86_64                                                                                                                                                                                    1/1

Installed:
  nano-5.6.1-5.el9.x86_64

Complete!
INFO[0018] Package installed:  nano
INFO[0018] Successful installation of:  nano
INFO[0018] Trying to install the package:
Last metadata expiration check: 0:00:11 ago on Fri Sep 30 19:52:02 2022.
No match for argument:
Error: Unable to find a match
ERRO[0019] Could not install the package.                error="exit status 1"
INFO[0019] Fail to install:
INFO[0019] Total success package's installation: [vim nano]
INFO[0019] Total fail package's installation: []
```

snap
```
root@ubuntu-s-4vcpu-8gb-nyc1-01:~/trouxa# echo -n "jq" > packages.txt

root@ubuntu-s-4vcpu-8gb-nyc1-01:~# ./build/trouxa -m snap -p packages.txt
INFO[0000] Trying to install the package:  jq
jq 1.5+dfsg-1 from Michael Vogt (mvo✪) installed
INFO[0001] Package installed:  jq
INFO[0001] Successful installation of:  jq
INFO[0001] Total success package's installation: [jq]
INFO[0001] Total fail package's installation: []
```

yum
```
$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src rockylinux:9.0 /bin/bash

[root@4e2c461b1f21 src]# ./build/trouxa -m yum -p packages.txt
INFO[0000] Trying to install the package:  vim
Rocky Linux 9 - BaseOS                                                                                                                                                                              1.9 MB/s | 1.7 MB     00:00
Rocky Linux 9 - AppStream                                                                                                                                                                            15 MB/s | 6.0 MB     00:00
Rocky Linux 9 - Extras                                                                                                                                                                               20 kB/s | 6.6 kB     00:00
Dependencies resolved.
====================================================================================================================================================================================================================================
 Package                                                 Architecture                                    Version                                                           Repository                                          Size
====================================================================================================================================================================================================================================
Installing:
 vim-enhanced                                            x86_64                                          2:8.2.2637-16.el9_0.3                                             appstream                                          1.8 M
Installing dependencies:
 gpm-libs                                                x86_64                                          1.20.7-29.el9                                                     appstream                                           20 k
 vim-common                                              x86_64                                          2:8.2.2637-16.el9_0.3                                             appstream                                          6.6 M
 vim-filesystem                                          noarch                                          2:8.2.2637-16.el9_0.3                                             baseos                                              20 k
 which                                                   x86_64                                          2.21-27.el9                                                       baseos                                              41 k

Transaction Summary
====================================================================================================================================================================================================================================
Install  5 Packages

Total download size: 8.4 M
Installed size: 34 M
Downloading Packages:
Rocky Linux 9 - BaseOS                                                                        192% [================================================================================================================================(1/5): vim-enhanced-8.2.2637-16.el9_0.3.x86_64.rpm                                                                                                                                                   14 MB/s | 1.8 MB     00:00
(2/5): vim-filesystem-8.2.2637-16.el9_0.3.noarch.rpm                                                                                                                                                129 kB/s |  20 kB     00:00
(3/5): which-2.21-27.el9.x86_64.rpm                                                                                                                                                                 239 kB/s |  41 kB     00:00
(4/5): gpm-libs-1.20.7-29.el9.x86_64.rpm                                                                                                                                                            405 kB/s |  20 kB     00:00
(5/5): vim-common-8.2.2637-16.el9_0.3.x86_64.rpm                                                                                                                                                     39 MB/s | 6.6 MB     00:00
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                                                13 MB/s | 8.4 MB     00:00
Rocky Linux 9 - BaseOS                                                                                                                                                                              1.7 MB/s | 1.7 kB     00:00
Importing GPG key 0x350D275D:
 Userid     : "Rocky Enterprise Software Foundation - Release key 2022 <releng@rockylinux.org>"
 Fingerprint: 21CB 256A E16F C54C 6E65 2949 702D 426D 350D 275D
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-Rocky-9
Key imported successfully
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                            1/1
  Installing       : gpm-libs-1.20.7-29.el9.x86_64                                                                                                                                                                              1/5
  Installing       : vim-filesystem-2:8.2.2637-16.el9_0.3.noarch                                                                                                                                                                2/5
  Installing       : vim-common-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                    3/5
  Installing       : which-2.21-27.el9.x86_64                                                                                                                                                                                   4/5
  Installing       : vim-enhanced-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                  5/5
  Running scriptlet: vim-enhanced-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                  5/5
  Verifying        : which-2.21-27.el9.x86_64                                                                                                                                                                                   1/5
  Verifying        : vim-filesystem-2:8.2.2637-16.el9_0.3.noarch                                                                                                                                                                2/5
  Verifying        : vim-enhanced-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                  3/5
  Verifying        : vim-common-2:8.2.2637-16.el9_0.3.x86_64                                                                                                                                                                    4/5
  Verifying        : gpm-libs-1.20.7-29.el9.x86_64                                                                                                                                                                              5/5

Installed:
  gpm-libs-1.20.7-29.el9.x86_64          vim-common-2:8.2.2637-16.el9_0.3.x86_64          vim-enhanced-2:8.2.2637-16.el9_0.3.x86_64          vim-filesystem-2:8.2.2637-16.el9_0.3.noarch          which-2.21-27.el9.x86_64

Complete!
INFO[0011] Package installed:  vim
INFO[0011] Successful installation of:  vim
INFO[0011] Trying to install the package:  nano
Last metadata expiration check: 0:00:07 ago on Fri Sep 30 20:16:35 2022.
Dependencies resolved.
====================================================================================================================================================================================================================================
 Package                                             Architecture                                          Version                                                      Repository                                             Size
====================================================================================================================================================================================================================================
Installing:
 nano                                                x86_64                                                5.6.1-5.el9                                                  baseos                                                694 k

Transaction Summary
====================================================================================================================================================================================================================================
Install  1 Package

Total download size: 694 k
Installed size: 2.7 M
Downloading Packages:
nano-5.6.1-5.el9.x86_64.rpm                                                                                                                                                                         1.7 MB/s | 694 kB     00:00
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Total                                                                                                                                                                                               1.2 MB/s | 694 kB     00:00
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                                                                                                                                                                            1/1
  Installing       : nano-5.6.1-5.el9.x86_64                                                                                                                                                                                    1/1
  Running scriptlet: nano-5.6.1-5.el9.x86_64                                                                                                                                                                                    1/1
  Verifying        : nano-5.6.1-5.el9.x86_64                                                                                                                                                                                    1/1

Installed:
  nano-5.6.1-5.el9.x86_64

Complete!
INFO[0012] Package installed:  nano
INFO[0012] Successful installation of:  nano
INFO[0012] Trying to install the package:
Last metadata expiration check: 0:00:08 ago on Fri Sep 30 20:16:35 2022.
No match for argument:
Error: Unable to find a match
ERRO[0013] Could not install the package.                error="exit status 1"
INFO[0013] Fail to install:
INFO[0013] Total success package's installation: [vim nano]
INFO[0013] Total fail package's installation: []
```

zypper
```
$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src opensuse/leap:15.3 /bin/bash

104c241487a0:/src # ./build/trouxa -m zypper -p packages.txt
INFO[0000] Trying to install the package:  vim
Retrieving repository 'Update repository of openSUSE Backports' metadata .....................................................................................................................................................[done]
Building repository 'Update repository of openSUSE Backports' cache ..........................................................................................................................................................[done]
Retrieving repository 'Non-OSS Repository' metadata -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------[/]
Note: Received 1 new package signing key from repository "Non-OSS Repository":

  Those additional keys are usually used to sign packages shipped by the repository. In order to
  validate those packages upon download and installation the new keys will be imported into the rpm
  database.

  New:
  Key Fingerprint:  4E98 E675 19D9 8DC7 362A 5990 E3A5 C360 307E 3D54
  Key Name:         SuSE Package Signing Key <build@suse.de>
  Key Algorithm:    RSA 1024
  Key Created:      Thu Mar 15 15:26:29 2018
  Key Expires:      Mon Mar 14 15:26:29 2022 (EXPIRED)
  Rpm Name:         gpg-pubkey-307e3d54-5aaa90a5

  The repository metadata introducing the new keys have been signed and validated by the trusted
  key:

  Repository:       Non-OSS Repository
  Key Fingerprint:  22C0 7BA5 3417 8CD0 2EFE 22AA B88B 2FD4 3DBD C284
  Key Name:         openSUSE Project Signing Key <opensuse@opensuse.org>
  Key Algorithm:    RSA 2048
  Key Created:      Mon May  5 08:37:40 2014
  Key Expires:      Thu May  2 08:37:40 2024
  Rpm Name:         gpg-pubkey-3dbdc284-53674dd4

Retrieving repository 'Non-OSS Repository' metadata ..........................................................................................................................................................................[done]
Building repository 'Non-OSS Repository' cache ...............................................................................................................................................................................[done]
Retrieving repository 'Main Repository' metadata .............................................................................................................................................................................[done]
Building repository 'Main Repository' cache ..................................................................................................................................................................................[done]
Retrieving repository 'Update repository with updates from SUSE Linux Enterprise 15' metadata ................................................................................................................................[done]
Building repository 'Update repository with updates from SUSE Linux Enterprise 15' cache .....................................................................................................................................[done]
Retrieving repository 'Main Update Repository' metadata ......................................................................................................................................................................[done]
Building repository 'Main Update Repository' cache ...........................................................................................................................................................................[done]
Retrieving repository 'Update Repository (Non-Oss)' metadata .................................................................................................................................................................[done]
Building repository 'Update Repository (Non-Oss)' cache ......................................................................................................................................................................[done]
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following 4 NEW packages are going to be installed:
  libgdbm4 perl vim vim-data-common

4 new packages to install.
Overall download size: 8.8 MiB. Already cached: 0 B. After the operation, additional 45.2 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving package libgdbm4-1.12-1.418.x86_64                                                                                                                                                  (1/4),  76.5 KiB (251.7 KiB unpacked)
Retrieving: libgdbm4-1.12-1.418.x86_64.rpm ...................................................................................................................................................................................[done]
Retrieving package vim-data-common-9.0.0313-150000.5.25.1.noarch                                                                                                                               (2/4), 271.0 KiB (437.7 KiB unpacked)
Retrieving: vim-data-common-9.0.0313-150000.5.25.1.noarch.rpm ................................................................................................................................................................[done]
Retrieving package perl-5.26.1-150300.17.11.1.x86_64                                                                                                                                           (3/4),   6.6 MiB ( 40.5 MiB unpacked)
Retrieving: perl-5.26.1-150300.17.11.1.x86_64.rpm ............................................................................................................................................................................[done]
Retrieving package vim-9.0.0313-150000.5.25.1.x86_64                                                                                                                                           (4/4),   1.9 MiB (  4.0 MiB unpacked)
Retrieving: vim-9.0.0313-150000.5.25.1.x86_64.rpm ............................................................................................................................................................................[done]

Checking for file conflicts: .................................................................................................................................................................................................[done]
(1/4) Installing: libgdbm4-1.12-1.418.x86_64 .................................................................................................................................................................................[done]
(2/4) Installing: vim-data-common-9.0.0313-150000.5.25.1.noarch ..............................................................................................................................................................[done]
(3/4) Installing: perl-5.26.1-150300.17.11.1.x86_64 ..........................................................................................................................................................................[done]
update-alternatives: using /usr/bin/vim-nox11 to provide /usr/bin/vim (vim) in auto mode
(4/4) Installing: vim-9.0.0313-150000.5.25.1.x86_64 ..........................................................................................................................................................................[done]
INFO[0088] Package installed:  vim
INFO[0088] Successful installation of:  vim
INFO[0088] Trying to install the package:  nano
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  nano

1 new package to install.
Overall download size: 506.4 KiB. Already cached: 0 B. After the operation, additional 1.6 MiB will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving package nano-4.9.2-bp153.1.19.x86_64                                                                                                                                                (1/1), 506.4 KiB (  1.6 MiB unpacked)
Retrieving: nano-4.9.2-bp153.1.19.x86_64.rpm .................................................................................................................................................................................[done]

Checking for file conflicts: .................................................................................................................................................................................................[done]
(1/1) Installing: nano-4.9.2-bp153.1.19.x86_64 ...............................................................................................................................................................................[done]
INFO[0096] Package installed:  nano
INFO[0096] Successful installation of:  nano
INFO[0096] Trying to install the package:
Loading repository data...
Reading installed packages...
Resolving package dependencies...
Nothing to do.
INFO[0104] Package installed:
INFO[0104] Successful installation of:
INFO[0104] Total success package's installation: [vim nano ]
INFO[0104] Total fail package's installation: []
```

Let me know if you'd like me to tweak anything!