### PR TITLE
add eopkg package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The binary compiled will be copied to your `/usr/bin` and available through the 
 - apt
 - aptitude
 - dnf
+- eopkg
 - pacman
 - snap
 - yay

--- a/internal/commander/commander.go
+++ b/internal/commander/commander.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Bainoware/trouxa/internal/manager/apt"
 	"github.com/Bainoware/trouxa/internal/manager/aptitude"
 	"github.com/Bainoware/trouxa/internal/manager/dnf"
+	"github.com/Bainoware/trouxa/internal/manager/eopkg"
 	"github.com/Bainoware/trouxa/internal/manager/pacman"
 	"github.com/Bainoware/trouxa/internal/manager/snap"
 	"github.com/Bainoware/trouxa/internal/manager/yay"
@@ -38,6 +39,8 @@ func FromName(name string) Commander {
 		return new(aptitude.Commander)
 	case "dnf":
 		return new(dnf.Commander)
+	case "eopkg":
+		return new(eopkg.Commaner)
 	case "pacman":
 		return new(pacman.Commander)
 	case "snap":

--- a/internal/commander/commander.go
+++ b/internal/commander/commander.go
@@ -40,7 +40,7 @@ func FromName(name string) Commander {
 	case "dnf":
 		return new(dnf.Commander)
 	case "eopkg":
-		return new(eopkg.Commaner)
+		return new(eopkg.Commander)
 	case "pacman":
 		return new(pacman.Commander)
 	case "snap":

--- a/internal/manager/eopkg/eopkg.go
+++ b/internal/manager/eopkg/eopkg.go
@@ -1,0 +1,18 @@
+package eopkg
+
+import (
+	"os/exec"
+)
+
+type Commander struct {
+}
+
+// BuildInstallCommand create the installation command to eopkg
+func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
+	return exec.Command("eopkg", "install", "-y", name)
+}
+
+// BuildUninstallCommand create the uninstallation command to eopkg
+func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
+	return exec.Command("eopkg", "remove", "-y", name)
+}


### PR DESCRIPTION
Inspired by #6 this PR adds the `eopkg` package manager, which is used, for example, by [Solus](https://getsol.us/home/)

Validated that binary still builds successfully (Ubuntu on WSL2)

Installing new packages:

```
$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src silkeh/solus /bin/bash
root@90126c7b1c96 /src # ./build/trouxa -m eopkg -p examples/packages.txt
INFO[0000] Trying to install the package:  vim
Following packages will be installed:
ruby  vim
Total size of package(s): 16.32 MB
Downloading 1 / 2
Package ruby found in repository Solus
ruby-3.0.4-23-1-x86_64.eopkg   (7.9 MB)100%    678.76 KB/s [00:00:10] [complete]
Downloading 2 / 2
Package vim found in repository Solus
vim-9.0.0260-128-1-x86_64.eopkg (8.4 MB)100%      4.49 MB/s [00:00:00] [complete]
Installing 1 / 2
ruby-3.0.4-23-1-x86_64.eopkg [cached]
Installing ruby, version 3.0.4, release 23
Extracting the files of ruby
Installed ruby
Installing 2 / 2
vim-9.0.0260-128-1-x86_64.eopkg [cached]
Installing vim, version 9.0.0260, release 128
Extracting the files of vim
Installed vim
 [✓] Syncing filesystems                                                success
 [✓] Updating dynamic library cache                                     success
 [✓] Updating icon theme cache: hicolor                                 success
 [✓] Updating desktop database                                          success
 [✓] Updating manpages database                                         success

INFO[0014] Package installed:  vim
INFO[0014] Successful installation of:  vim
INFO[0015] Total success package's installation: [vim]
```