### PR TITLE
Feat/add dump option

### DIFF
--- a/internal/commander/commander.go
+++ b/internal/commander/commander.go
@@ -20,6 +20,7 @@ import (
 type Commander interface {
 	BuildInstallCommand(name string) *exec.Cmd
 	BuildUninstallCommand(name string) *exec.Cmd
+	DumpPackages() *exec.Cmd
 }
 
 // FromName create a commander from a package manager mane

--- a/internal/commander/commander.go
+++ b/internal/commander/commander.go
@@ -21,7 +21,7 @@ import (
 type Commander interface {
 	BuildInstallCommand(name string) *exec.Cmd
 	BuildUninstallCommand(name string) *exec.Cmd
-	DumpPackages() *exec.Cmd
+	ListPackages() *exec.Cmd
 }
 
 // FromName create a commander from a package manager mane

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -35,9 +35,9 @@ Trouxa is a simple application to install and remove packages at once by just us
 		if commander == nil {
 			log.Fatalln("This package manager is not supported or invalid for your system!")
 		}
-		if dump, _ := command.Flags().GetBool("dump"); dump {
-			log.Debugln("Entered dump, will do nothing else")
-			ok, err := manager.ListPackages(commander.DumpPackages())
+		if list, _ := command.Flags().GetBool("list"); list {
+			log.Debugln("Entered list, will do nothing else")
+			ok, err := manager.ListPackages(commander.listPackages())
 			if !ok {
 				log.Errorln("Failed to list packages: ", err)
 				os.Exit(1)
@@ -83,7 +83,7 @@ func init() {
 		"./packages.txt",
 		"The file used by Trouxa to download de packages to your system")
 	RootCmd.Flags().Bool(
-		"dump",
+		"list",
 		false,
 		"List all installed packages in this package manager and exit")
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -20,7 +20,7 @@ var RootCmd = &cobra.Command{
 	Long: `
 Trouxa is a simple application to install and remove packages at once by just using a simple text file.
 `,
-	Version: "0.0.1",
+	Version: "0.1.0",
 	Run: func(command *cobra.Command, args []string) {
 		installPackage := func(name string, commander commander.Commander) bool {
 			ok, _ := manager.InstallPackage(name, commander.BuildInstallCommand(name))
@@ -34,6 +34,11 @@ Trouxa is a simple application to install and remove packages at once by just us
 		commander := commander.FromName(packageManager)
 		if commander == nil {
 			log.Fatalln("This package manager is not supported or invalid for your system!")
+		}
+		if dump, _ := command.Flags().GetBool("dump"); dump {
+			log.Debugln("Entered dump, will do nothing else")
+			manager.ListPackages(commander.DumpPackages())
+			os.Exit(0)
 		}
 		data, err := input.GetData(pathFilePackages)
 		if err != nil {
@@ -61,7 +66,7 @@ func init() {
 		"manager",
 		"m",
 		"",
-		"Package manager to download your packages. apt | pacman | yay | apk",
+		"Package manager to download your packages",
 	)
 	err := RootCmd.MarkFlagRequired("manager")
 	if err != nil {
@@ -73,4 +78,8 @@ func init() {
 		"p",
 		"./packages.txt",
 		"The file used by Trouxa to download de packages to your system")
+	RootCmd.Flags().Bool(
+		"dump",
+		false,
+		"List all installed packages in this package manager and exit")
 }

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -37,7 +37,7 @@ Trouxa is a simple application to install and remove packages at once by just us
 		}
 		if list, _ := command.Flags().GetBool("list"); list {
 			log.Debugln("Entered list, will do nothing else")
-			ok, err := manager.ListPackages(commander.listPackages())
+			ok, err := manager.ListPackages(commander.ListPackages())
 			if !ok {
 				log.Errorln("Failed to list packages: ", err)
 				os.Exit(1)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -37,7 +37,11 @@ Trouxa is a simple application to install and remove packages at once by just us
 		}
 		if dump, _ := command.Flags().GetBool("dump"); dump {
 			log.Debugln("Entered dump, will do nothing else")
-			manager.ListPackages(commander.DumpPackages())
+			ok, err := manager.ListPackages(commander.DumpPackages())
+			if !ok {
+				log.Errorln("Failed to list packages: ", err)
+				os.Exit(1)
+			}
 			os.Exit(0)
 		}
 		data, err := input.GetData(pathFilePackages)

--- a/internal/manager/apk/apk.go
+++ b/internal/manager/apk/apk.go
@@ -16,3 +16,8 @@ func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("apk", "del", name)
 }
+
+// DumpPackages lists all installed packages from apk
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("apk", "list", "--installed")
+}

--- a/internal/manager/apk/apk.go
+++ b/internal/manager/apk/apk.go
@@ -17,7 +17,7 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("apk", "del", name)
 }
 
-// DumpPackages lists all installed packages from apk
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from apk
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("apk", "list", "--installed")
 }

--- a/internal/manager/apt/apt.go
+++ b/internal/manager/apt/apt.go
@@ -16,3 +16,8 @@ func (a *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (a *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("apt", "remove", name, "-y")
 }
+
+// DumpPackages lists all installed packages from apt
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("apt", "list")
+}

--- a/internal/manager/apt/apt.go
+++ b/internal/manager/apt/apt.go
@@ -19,5 +19,5 @@ func (a *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 
 // DumpPackages lists all installed packages from apt
 func (a *Commander) DumpPackages() *exec.Cmd {
-	return exec.Command("apt", "list")
+	return exec.Command("apt", "list", "--installed")
 }

--- a/internal/manager/apt/apt.go
+++ b/internal/manager/apt/apt.go
@@ -17,7 +17,7 @@ func (a *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("apt", "remove", name, "-y")
 }
 
-// DumpPackages lists all installed packages from apt
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from apt
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("apt", "list", "--installed")
 }

--- a/internal/manager/aptitude/aptitude.go
+++ b/internal/manager/aptitude/aptitude.go
@@ -19,5 +19,5 @@ func (a *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 
 // DumpPackages lists all installed packages from aptitude
 func (a *Commander) DumpPackages() *exec.Cmd {
-	return exec.Command("aptitude", "list", "--installed")
+	return exec.Command("aptitude", "search", "~i")
 }

--- a/internal/manager/aptitude/aptitude.go
+++ b/internal/manager/aptitude/aptitude.go
@@ -16,3 +16,8 @@ func (a *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (a *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("aptitude", "remove", "-y", name)
 }
+
+// DumpPackages lists all installed packages from aptitude
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("aptitude", "list", "--installed")
+}

--- a/internal/manager/aptitude/aptitude.go
+++ b/internal/manager/aptitude/aptitude.go
@@ -17,7 +17,7 @@ func (a *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("aptitude", "remove", "-y", name)
 }
 
-// DumpPackages lists all installed packages from aptitude
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from aptitude
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("aptitude", "search", "~i")
 }

--- a/internal/manager/dnf/dnf.go
+++ b/internal/manager/dnf/dnf.go
@@ -17,7 +17,7 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("dnf", "remove", "-y", name)
 }
 
-// DumpPackages lists all installed packages from dnf
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from dnf
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("dnf", "list", "installed")
 }

--- a/internal/manager/dnf/dnf.go
+++ b/internal/manager/dnf/dnf.go
@@ -16,3 +16,8 @@ func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("dnf", "remove", "-y", name)
 }
+
+// DumpPackages lists all installed packages from dnf
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("dnf", "list", "installed")
+}

--- a/internal/manager/eopkg/eopkg.go
+++ b/internal/manager/eopkg/eopkg.go
@@ -17,7 +17,7 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("eopkg", "remove", "-y", name)
 }
 
-// DumpPackages lists all installed packages from eopkg
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from eopkg
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("eopkg", "li")
 }

--- a/internal/manager/eopkg/eopkg.go
+++ b/internal/manager/eopkg/eopkg.go
@@ -16,3 +16,8 @@ func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("eopkg", "remove", "-y", name)
 }
+
+// DumpPackages lists all installed packages from eopkg
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("eopkg", "li")
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -57,7 +57,7 @@ func UninstallPackage(name string, cmd *exec.Cmd) (bool, error) {
 	return true, nil
 }
 
-// ListPackages dumps all the installed packages via a package manager
+// ListPackages lists all the installed packages via a package manager
 func ListPackages(cmd *exec.Cmd) (bool, error) {
 	log.Infoln("Listing packages")
 	if ok, err := runCommand(cmd); !ok {

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -31,7 +31,7 @@ func IsValid(name string) error {
 	return nil
 }
 
-// InstallPackage install a package with the apt package manager
+// InstallPackage install a package with a package manager
 func InstallPackage(name string, cmd *exec.Cmd) (bool, error) {
 	log.Infoln("Trying to install the package: ", name)
 	if ok, err := runCommand(cmd); !ok {
@@ -44,7 +44,7 @@ func InstallPackage(name string, cmd *exec.Cmd) (bool, error) {
 	return true, nil
 }
 
-// UninstallPackage uninstall a package with the apt package manager
+// UninstallPackage uninstall a package with a package manager
 func UninstallPackage(name string, cmd *exec.Cmd) (bool, error) {
 	log.Infoln("Uninstalling package: ", name)
 	if ok, err := runCommand(cmd); !ok {
@@ -53,6 +53,18 @@ func UninstallPackage(name string, cmd *exec.Cmd) (bool, error) {
 		return false, err
 	}
 	log.Errorln("Package uninstalled: ", name)
+
+	return true, nil
+}
+
+// ListPackages dumps all the installed packages via a package manager
+func ListPackages(cmd *exec.Cmd) (bool, error) {
+	log.Infoln("Listing packages")
+	if ok, err := runCommand(cmd); !ok {
+		log.Errorln("Could not list packages: ", err)
+
+		return false, err
+	}
 
 	return true, nil
 }

--- a/internal/manager/pacman/pacman.go
+++ b/internal/manager/pacman/pacman.go
@@ -16,3 +16,8 @@ func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("pacman", "-Rs", name, "--noconfirm")
 }
+
+// DumpPackages lists all installed packages from pacman
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("pacman", "-Qe")
+}

--- a/internal/manager/pacman/pacman.go
+++ b/internal/manager/pacman/pacman.go
@@ -17,7 +17,7 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("pacman", "-Rs", name, "--noconfirm")
 }
 
-// DumpPackages lists all installed packages from pacman
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from pacman
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("pacman", "-Qe")
 }

--- a/internal/manager/snap/snap.go
+++ b/internal/manager/snap/snap.go
@@ -16,3 +16,8 @@ func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("snap", "remove", name)
 }
+
+// DumpPackages lists all installed packages from snap
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("snap", "list")
+}

--- a/internal/manager/snap/snap.go
+++ b/internal/manager/snap/snap.go
@@ -17,7 +17,7 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("snap", "remove", name)
 }
 
-// DumpPackages lists all installed packages from snap
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from snap
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("snap", "list", "--all")
 }

--- a/internal/manager/snap/snap.go
+++ b/internal/manager/snap/snap.go
@@ -19,5 +19,5 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 
 // DumpPackages lists all installed packages from snap
 func (a *Commander) DumpPackages() *exec.Cmd {
-	return exec.Command("snap", "list")
+	return exec.Command("snap", "list", "--all")
 }

--- a/internal/manager/yay/yay.go
+++ b/internal/manager/yay/yay.go
@@ -17,8 +17,8 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("yay", "-Rs", name, "--noconfirm")
 }
 
-// DumpPackages lists all installed packages from yay
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from yay
+func (a *Commander) ListPackages() *exec.Cmd {
 	// There seems to be no way of distinguishing between packages installed by pacman and yay:
 	// https://www.reddit.com/r/archlinux/comments/woh8fr/comment/ikb075w/?utm_source=reddit&utm_medium=web2x&context=3
 	// So the command ends up being virtually the same here

--- a/internal/manager/yay/yay.go
+++ b/internal/manager/yay/yay.go
@@ -16,3 +16,11 @@ func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("yay", "-Rs", name, "--noconfirm")
 }
+
+// DumpPackages lists all installed packages from yay
+func (a *Commander) DumpPackages() *exec.Cmd {
+	// There seems to be no way of distinguishing between packages installed by pacman and yay:
+	// https://www.reddit.com/r/archlinux/comments/woh8fr/comment/ikb075w/?utm_source=reddit&utm_medium=web2x&context=3
+	// So the command ends up being virtually the same here
+	return exec.Command("yay", "-Qe")
+}

--- a/internal/manager/yum/yum.go
+++ b/internal/manager/yum/yum.go
@@ -16,3 +16,8 @@ func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("yum", "remove", "-y", name)
 }
+
+// DumpPackages lists all installed packages from yum
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("yum", "list", "installed")
+}

--- a/internal/manager/yum/yum.go
+++ b/internal/manager/yum/yum.go
@@ -17,7 +17,7 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("yum", "remove", "-y", name)
 }
 
-// DumpPackages lists all installed packages from yum
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from yum
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("yum", "list", "installed")
 }

--- a/internal/manager/zypper/zypper.go
+++ b/internal/manager/zypper/zypper.go
@@ -17,7 +17,7 @@ func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("zypper", "remove", "-y", name)
 }
 
-// DumpPackages lists all installed packages from zypper
-func (a *Commander) DumpPackages() *exec.Cmd {
+// ListPackages lists all installed packages from zypper
+func (a *Commander) ListPackages() *exec.Cmd {
 	return exec.Command("zypper", "search", "--installed-only")
 }

--- a/internal/manager/zypper/zypper.go
+++ b/internal/manager/zypper/zypper.go
@@ -16,3 +16,8 @@ func (p *Commander) BuildInstallCommand(name string) *exec.Cmd {
 func (p *Commander) BuildUninstallCommand(name string) *exec.Cmd {
 	return exec.Command("zypper", "remove", "-y", name)
 }
+
+// DumpPackages lists all installed packages from zypper
+func (a *Commander) DumpPackages() *exec.Cmd {
+	return exec.Command("zypper", "search", "--installed-only")
+}


### PR DESCRIPTION
Inspired by #10 

Adds a `--dump` option that overrides every other currently available option and that list all installed packages through a specific package manager. Bump version to `0.1.0` due to this new option.

New version builds successfully in Ubuntu 20.04.4 LTS through WSL 2

Example use:

<details> <summary>apt</summary>

```
~/trouxa$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src debian:11.5 /bin/bash
Unable to find image 'debian:11.5' locally
11.5: Pulling from library/debian
f606d8928ed3: Pull complete
Digest: sha256:e538a2f0566efc44db21503277c7312a142f4d0dedc5d2886932b92626104bff
Status: Downloaded newer image for debian:11.5
root@e91cff24f164:/src# ./build/trouxa -m apt --dump
INFO[0000] Listing packages
Listing... Done
adduser/now 3.118 all [installed,local]
apt/now 2.2.4 amd64 [installed,local]
base-files/now 11.1+deb11u5 amd64 [installed,local]
base-passwd/now 3.5.51 amd64 [installed,local]
bash/now 5.1-2+deb11u1 amd64 [installed,local]
bsdutils/now 1:2.36.1-8+deb11u1 amd64 [installed,local]
coreutils/now 8.32-4+b1 amd64 [installed,local]
dash/now 0.5.11+git20200708+dd9ef66-5 amd64 [installed,local]
debconf/now 1.5.77 all [installed,local]
debian-archive-keyring/now 2021.1.1 all [installed,local]
debianutils/now 4.11.2 amd64 [installed,local]
diffutils/now 1:3.7-5 amd64 [installed,local]
dpkg/now 1.20.12 amd64 [installed,local]
e2fsprogs/now 1.46.2-2 amd64 [installed,local]
findutils/now 4.8.0-1 amd64 [installed,local]
root@e91cff24f164:/src#
gcc-9-base/now 9.3.0-22 amd64 [installed,local]
gpgv/now 2.2.27-2+deb11u2 amd64 [installed,local]
grep/now 3.6-1 amd64 [installed,local]
gzip/now 1.10-4+deb11u1 amd64 [installed,local]
hostname/now 3.23 amd64 [installed,local]
init-system-helpers/now 1.60 all [installed,local]
libacl1/now 2.2.53-10 amd64 [installed,local]
libapt-pkg6.0/now 2.2.4 amd64 [installed,local]
libattr1/now 1:2.4.48-6 amd64 [installed,local]
libaudit-common/now 1:3.0-2 all [installed,local]
libaudit1/now 1:3.0-2 amd64 [installed,local]
libblkid1/now 2.36.1-8+deb11u1 amd64 [installed,local]
libbz2-1.0/now 1.0.8-4 amd64 [installed,local]
libc-bin/now 2.31-13+deb11u4 amd64 [installed,local]
libc6/now 2.31-13+deb11u4 amd64 [installed,local]
libcap-ng0/now 0.7.9-2.2+b1 amd64 [installed,local]
libcom-err2/now 1.46.2-2 amd64 [installed,local]
libcrypt1/now 1:4.4.18-4 amd64 [installed,local]
libdb5.3/now 5.3.28+dfsg1-0.8 amd64 [installed,local]
libdebconfclient0/now 0.260 amd64 [installed,local]
libext2fs2/now 1.46.2-2 amd64 [installed,local]
libffi7/now 3.3-6 amd64 [installed,local]
libgcc-s1/now 10.2.1-6 amd64 [installed,local]
libgcrypt20/now 1.8.7-6 amd64 [installed,local]
libgmp10/now 2:6.2.1+dfsg-1+deb11u1 amd64 [installed,local]
libgnutls30/now 3.7.1-5+deb11u2 amd64 [installed,local]
libgpg-error0/now 1.38-2 amd64 [installed,local]
libgssapi-krb5-2/now 1.18.3-6+deb11u2 amd64 [installed,local]
libhogweed6/now 3.7.3-1 amd64 [installed,local]
libidn2-0/now 2.3.0-5 amd64 [installed,local]
libk5crypto3/now 1.18.3-6+deb11u2 amd64 [installed,local]
libkeyutils1/now 1.6.1-2 amd64 [installed,local]
libkrb5-3/now 1.18.3-6+deb11u2 amd64 [installed,local]
libkrb5support0/now 1.18.3-6+deb11u2 amd64 [installed,local]
liblz4-1/now 1.9.3-2 amd64 [installed,local]
liblzma5/now 5.2.5-2.1~deb11u1 amd64 [installed,local]
libmount1/now 2.36.1-8+deb11u1 amd64 [installed,local]
libnettle8/now 3.7.3-1 amd64 [installed,local]
libnsl2/now 1.3.0-2 amd64 [installed,local]
libp11-kit0/now 0.23.22-1 amd64 [installed,local]
libpam-modules-bin/now 1.4.0-9+deb11u1 amd64 [installed,local]
libpam-modules/now 1.4.0-9+deb11u1 amd64 [installed,local]
libpam-runtime/now 1.4.0-9+deb11u1 all [installed,local]
libpam0g/now 1.4.0-9+deb11u1 amd64 [installed,local]
libpcre2-8-0/now 10.36-2+deb11u1 amd64 [installed,local]
libpcre3/now 2:8.39-13 amd64 [installed,local]
libseccomp2/now 2.5.1-1+deb11u1 amd64 [installed,local]
libselinux1/now 3.1-3 amd64 [installed,local]
libsemanage-common/now 3.1-1 all [installed,local]
libsemanage1/now 3.1-1+b2 amd64 [installed,local]
libsepol1/now 3.1-1 amd64 [installed,local]
libsmartcols1/now 2.36.1-8+deb11u1 amd64 [installed,local]
libss2/now 1.46.2-2 amd64 [installed,local]
libssl1.1/now 1.1.1n-0+deb11u3 amd64 [installed,local]
libstdc++6/now 10.2.1-6 amd64 [installed,local]
libsystemd0/now 247.3-7+deb11u1 amd64 [installed,local]
libtasn1-6/now 4.16.0-2 amd64 [installed,local]
libtinfo6/now 6.2+20201114-2 amd64 [installed,local]
libtirpc-common/now 1.3.1-1+deb11u1 all [installed,local]
libtirpc3/now 1.3.1-1+deb11u1 amd64 [installed,local]
libudev1/now 247.3-7+deb11u1 amd64 [installed,local]
libunistring2/now 0.9.10-4 amd64 [installed,local]
libuuid1/now 2.36.1-8+deb11u1 amd64 [installed,local]
libxxhash0/now 0.8.0-2 amd64 [installed,local]
libzstd1/now 1.4.8+dfsg-2.1 amd64 [installed,local]
login/now 1:4.8.1-1 amd64 [installed,local]
logsave/now 1.46.2-2 amd64 [installed,local]
lsb-base/now 11.1.0 all [installed,local]
mawk/now 1.3.4.20200120-2 amd64 [installed,local]
mount/now 2.36.1-8+deb11u1 amd64 [installed,local]
ncurses-base/now 6.2+20201114-2 all [installed,local]
ncurses-bin/now 6.2+20201114-2 amd64 [installed,local]
passwd/now 1:4.8.1-1 amd64 [installed,local]
perl-base/now 5.32.1-4+deb11u2 amd64 [installed,local]
sed/now 4.7-1 amd64 [installed,local]
sysvinit-utils/now 2.96-7+deb11u1 amd64 [installed,local]
tar/now 1.34+dfsg-1 amd64 [installed,local]
tzdata/now 2021a-1+deb11u6 all [installed,local]
util-linux/now 2.36.1-8+deb11u1 amd64 [installed,local]
zlib1g/now 1:1.2.11.dfsg-2+deb11u2 amd64 [installed,local]
```

</details>

<details> <summary>aptitude</summary>

```
root@2574531e7b07:/src# ./build/trouxa -m aptitude --dump
INFO[0000] Listing packages
i A adduser                                            - add and remove users and groups
i A apt                                                - commandline package manager
i   aptitude                                           - terminal-based package manager
i A aptitude-common                                    - architecture independent files for the aptitude package manag
i A base-files                                         - Debian base system miscellaneous files
i A base-passwd                                        - Debian base system master password and group files
i A bash                                               - GNU Bourne Again SHell
i A bsdutils                                           - basic utilities from 4.4BSD-Lite
i A bzip2                                              - high-quality block-sorting file compressor - utilities
i A coreutils                                          - GNU core utilities
i A dash                                               - POSIX-compliant shell
i A debconf                                            - Debian configuration management system
i A debian-archive-keyring                             - GnuPG archive keys of the Debian archive
i A debianutils                                        - Miscellaneous utilities specific to Debian
i A diffutils                                          - File comparison utilities
i A dpkg                                               - Debian package management system
i A e2fsprogs                                          - ext2/ext3/ext4 file system utilities
i A findutils                                          - utilities for finding files--find, xargs
i A gcc-10-base                                        - GCC, the GNU Compiler Collection (base package)
i A gcc-9-base                                         - GCC, the GNU Compiler Collection (base package)
i A gpgv                                               - GNU privacy guard - signature verification tool
i A grep                                               - GNU grep, egrep and fgrep
i A gzip                                               - GNU compression utilities
i A hostname                                           - utility to set/show the host name or domain name
i A init-system-helpers                                - helper tools for all init systems
i A libacl1                                            - access control list - shared library
i A libapt-pkg6.0                                      - package management runtime library
i A libattr1                                           - extended attribute handling - shared library
i A libaudit-common                                    - Dynamic library for security auditing - common files
i A libaudit1                                          - Dynamic library for security auditing
i A libblkid1                                          - block device ID library
i A libboost-iostreams1.74.0                           - Boost.Iostreams Library
i A libbz2-1.0                                         - high-quality block-sorting file compressor library - runtime
i A libc-bin                                           - GNU C Library: Binaries
i A libc6                                              - GNU C Library: Shared libraries
i A libcap-ng0                                         - An alternate POSIX capabilities library
i A libcom-err2                                        - common error description library
i A libcrypt1                                          - libcrypt shared library
i A libcwidget4                                        - high-level terminal interface library for C++ (runtime files)
i A libdb5.3                                           - Berkeley v5.3 Database Libraries [runtime]
i A libdebconfclient0                                  - Debian Configuration Management System (C-implementation libr
i A libdpkg-perl                                       - Dpkg perl modules
i A libext2fs2                                         - ext2/ext3/ext4 file system libraries
i A libffi7                                            - Foreign Function Interface library runtime
i A libfile-fcntllock-perl                             - Perl module for file locking with fcntl(2)
i A libgcc-s1                                          - GCC support library
i A libgcrypt20                                        - LGPL Crypto library - runtime library
i A libgdbm-compat4                                    - GNU dbm database routines (legacy support runtime version)
i A libgdbm6                                           - GNU dbm database routines (runtime version)
i A libgmp10                                           - Multiprecision arithmetic library
i A libgnutls30                                        - GNU TLS library - main runtime library
i A libgpg-error0                                      - GnuPG development runtime library
i A libgpm2                                            - General Purpose Mouse - shared library
i A libgssapi-krb5-2                                   - MIT Kerberos runtime libraries - krb5 GSS-API Mechanism
i A libhogweed6                                        - low level cryptographic library (public-key cryptos)
i A libidn2-0                                          - Internationalized domain names (IDNA2008/TR46) library
i A libk5crypto3                                       - MIT Kerberos runtime libraries - Crypto Library
i A libkeyutils1                                       - Linux Key Management Utilities (library)
i A libkrb5-3                                          - MIT Kerberos runtime libraries
i A libkrb5support0                                    - MIT Kerberos runtime libraries - Support library
i A liblocale-gettext-perl                             - module using libc functions for internationalization in Perl
i A liblz4-1                                           - Fast LZ compression algorithm library - runtime
i A liblzma5                                           - XZ-format compression library
i A libmount1                                          - device mounting library
i A libncursesw6                                       - shared libraries for terminal handling (wide character suppor
i A libnettle8                                         - low level cryptographic library (symmetric and one-way crypto
i A libnsl2                                            - Public client interface for NIS(YP) and NIS+
i A libp11-kit0                                        - library for loading and coordinating access to PKCS#11 module
i A libpam-modules                                     - Pluggable Authentication Modules for PAM
i A libpam-modules-bin                                 - Pluggable Authentication Modules for PAM - helper binaries
i A libpam-runtime                                     - Runtime support for the PAM library
i A libpam0g                                           - Pluggable Authentication Modules library
i A libpcre2-8-0                                       - New Perl Compatible Regular Expression Library- 8 bit runtime
i A libpcre3                                           - Old Perl 5 Compatible Regular Expression Library - runtime fi
i A libperl5.32                                        - shared Perl library
i A libseccomp2                                        - high level interface to Linux seccomp filter
i A libselinux1                                        - SELinux runtime shared libraries
i A libsemanage-common                                 - Common files for SELinux policy management libraries
i A libsemanage1                                       - SELinux policy management library
i A libsepol1                                          - SELinux library for manipulating binary security policies
i A libsigc++-2.0-0v5                                  - type-safe Signal Framework for C++ - runtime
i A libsmartcols1                                      - smart column output alignment library
i A libsqlite3-0                                       - SQLite 3 shared library
i A libss2                                             - command-line interface parsing library
i A libssl1.1                                          - Secure Sockets Layer toolkit - shared libraries
i A libstdc++6                                         - GNU Standard C++ Library v3
i A libsystemd0                                        - systemd utility library
i A libtasn1-6                                         - Manage ASN.1 structures (runtime)
i A libtinfo6                                          - shared low-level terminfo library for terminal handling
i A libtirpc-common                                    - transport-independent RPC library - common files
i A libtirpc3                                          - transport-independent RPC library
i A libudev1                                           - libudev shared library
i A libunistring2                                      - Unicode string library for C
i A libuuid1                                           - Universally Unique ID library
i A libxapian30                                        - Search engine library
i A libxxhash0                                         - shared library for xxhash
i A libzstd1                                           - fast lossless compression algorithm
i A login                                              - system login tools
i A logsave                                            - save the output of a command in a log file
i A lsb-base                                           - Linux Standard Base init script functionality
i A mawk                                               - Pattern scanning and text processing language
i A mount                                              - tools for mounting and manipulating filesystems
i A ncurses-base                                       - basic terminal type definitions
i A ncurses-bin                                        - terminal-related programs and man pages
i A netbase                                            - Basic TCP/IP networking system
i A passwd                                             - change and administer password and group data
i A perl                                               - Larry Wall's Practical Extraction and Report Language
i A perl-base                                          - minimal Perl system
i A perl-modules-5.32                                  - Core Perl modules
i A sed                                                - GNU stream editor for filtering/transforming text
i A sensible-utils                                     - Utilities for sensible alternative selection
i A sysvinit-utils                                     - System-V-like utilities
i A tar                                                - GNU version of the tar archiving utility
i A tzdata                                             - time zone and daylight-saving time data
i A util-linux                                         - miscellaneous system utilities
i A xz-utils                                           - XZ-format compression utilities
i A zlib1g                                             - compression library - runtime
```

</details>

<details> <summary>apk</summary>

```
~/trouxa$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src alpine
/src # apk add libc6-compat # Needed to run generated binary
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
(1/1) Installing libc6-compat (1.2.3-r0)
OK: 6 MiB in 15 packages
/src # ./build/trouxa -m apk --dump
INFO[0000] Listing packages
musl-1.2.3-r0 x86_64 {musl} (MIT) [installed]
zlib-1.2.12-r3 x86_64 {zlib} (Zlib) [installed]
apk-tools-2.12.9-r3 x86_64 {apk-tools} (GPL-2.0-only) [installed]
libc6-compat-1.2.3-r0 x86_64 {musl} (MIT) [installed]
musl-utils-1.2.3-r0 x86_64 {musl} (MIT BSD GPL2+) [installed]
libssl1.1-1.1.1q-r0 x86_64 {openssl} (OpenSSL) [installed]
alpine-baselayout-3.2.0-r22 x86_64 {alpine-baselayout} (GPL-2.0-only) [installed]
alpine-keys-2.4-r1 x86_64 {alpine-keys} (MIT) [installed]
busybox-1.35.0-r17 x86_64 {busybox} (GPL-2.0-only) [installed]
scanelf-1.3.4-r0 x86_64 {pax-utils} (GPL-2.0-only) [installed]
ca-certificates-bundle-20220614-r0 x86_64 {ca-certificates} (MPL-2.0 AND MIT) [installed]
libc-utils-0.7.2-r3 x86_64 {libc-dev} (BSD-2-Clause AND BSD-3-Clause) [installed]
ssl_client-1.35.0-r17 x86_64 {busybox} (GPL-2.0-only) [installed]
alpine-baselayout-data-3.2.0-r22 x86_64 {alpine-baselayout} (GPL-2.0-only) [installed]
libcrypto1.1-1.1.1q-r0 x86_64 {openssl} (OpenSSL) [installed]
```

</details>

<details> <summary>dnf</summary>

```
~/trouxa$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src rockylinux:9.0 /bin/bash
Unable to find image 'rockylinux:9.0' locally
9.0: Pulling from library/rockylinux
6cd61d51950e: Pull complete
Digest: sha256:589b293b63aa244aba2fdd20614b11cbe9905f94f657d7c62e7fcad8bffbb37a
Status: Downloaded newer image for rockylinux:9.0
[root@dd6fc8e4245d src]# ./build/trouxa -m dnf --dump
INFO[0000] Listing packages
Installed Packages
acl.x86_64                                                2.3.1-3.el9                                          @System
alternatives.x86_64                                       1.20-2.el9                                           @System
audit-libs.x86_64                                         3.0.7-101.el9_0.2                                    @System
basesystem.noarch                                         11-13.el9                                            @System
bash.x86_64                                               5.1.8-4.el9                                          @System
binutils.x86_64                                           2.35.2-17.el9                                        @System
binutils-gold.x86_64                                      2.35.2-17.el9                                        @System
bzip2-libs.x86_64                                         1.0.8-8.el9                                          @System
ca-certificates.noarch                                    2020.2.50-94.el9                                     @System
coreutils-single.x86_64                                   8.32-31.el9                                          @System
cracklib.x86_64                                           2.9.6-27.el9                                         @System
cracklib-dicts.x86_64                                     2.9.6-27.el9                                         @System
crypto-policies.noarch                                    20220223-1.git5203b41.el9_0.1                        @System
cryptsetup-libs.x86_64                                    2.4.3-4.el9                                          @System
curl.x86_64                                               7.76.1-14.el9_0.4                                    @System
cyrus-sasl-lib.x86_64                                     2.1.27-20.el9                                        @System
dbus.x86_64                                               1:1.12.20-5.el9                                      @System
dbus-broker.x86_64                                        28-5.el9                                             @System
dbus-common.noarch                                        1:1.12.20-5.el9                                      @System
dejavu-sans-fonts.noarch                                  2.37-18.el9                                          @System
device-mapper.x86_64                                      9:1.02.183-4.el9                                     @System
device-mapper-libs.x86_64                                 9:1.02.183-4.el9                                     @System
dnf.noarch                                                4.10.0-5.el9_0                                       @System
dnf-data.noarch                                           4.10.0-5.el9_0                                       @System
elfutils-debuginfod-client.x86_64                         0.186-1.el9                                          @System
elfutils-default-yama-scope.noarch                        0.186-1.el9                                          @System
elfutils-libelf.x86_64                                    0.186-1.el9                                          @System
elfutils-libs.x86_64                                      0.186-1.el9                                          @System
expat.x86_64                                              2.2.10-12.el9_0.2                                    @System
file-libs.x86_64                                          5.39-8.el9                                           @System
filesystem.x86_64                                         3.16-2.el9                                           @System
fonts-filesystem.noarch                                   1:2.0.5-7.el9.1                                      @System
gawk.x86_64                                               5.1.0-6.el9                                          @System
gdbm-libs.x86_64                                          1:1.19-4.el9                                         @System
glib2.x86_64                                              2.68.4-5.el9                                         @System
glibc.x86_64                                              2.34-28.el9_0                                        @System
glibc-common.x86_64                                       2.34-28.el9_0                                        @System
glibc-minimal-langpack.x86_64                             2.34-28.el9_0                                        @System
gmp.x86_64                                                1:6.2.0-10.el9                                       @System
gnupg2.x86_64                                             2.3.3-1.el9                                          @System
gnutls.x86_64                                             3.7.3-9.el9                                          @System
gpgme.x86_64                                              1.15.1-6.el9                                         @System
grep.x86_64                                               3.6-5.el9                                            @System
gzip.x86_64                                               1.10-9.el9_0                                         @System
hostname.x86_64                                           3.23-6.el9                                           @System
ima-evm-utils.x86_64                                      1.4-4.el9                                            @System
iputils.x86_64                                            20210202-7.el9                                       @System
json-c.x86_64                                             0.14-11.el9                                          @System
keyutils-libs.x86_64                                      1.6.1-4.el9                                          @System
kmod-libs.x86_64                                          28-7.el9                                             @System
krb5-libs.x86_64                                          1.19.1-15.el9_0                                      @System
langpacks-core-en.noarch                                  3.0-16.el9                                           @System
langpacks-core-font-en.noarch                             3.0-16.el9                                           @System
langpacks-en.noarch                                       3.0-16.el9                                           @System
less.x86_64                                               590-1.el9_0                                          @System
libacl.x86_64                                             2.3.1-3.el9                                          @System
libarchive.x86_64                                         3.5.3-2.el9_0                                        @System
libassuan.x86_64                                          2.5.5-3.el9                                          @System
libattr.x86_64                                            2.5.1-3.el9                                          @System
libblkid.x86_64                                           2.37.4-3.el9                                         @System
libbrotli.x86_64                                          1.0.9-6.el9                                          @System
libcap.x86_64                                             2.48-8.el9                                           @System
libcap-ng.x86_64                                          0.8.2-7.el9                                          @System
libcom_err.x86_64                                         1.46.5-2.el9                                         @System
libcomps.x86_64                                           0.1.18-1.el9                                         @System
libcurl.x86_64                                            7.76.1-14.el9_0.4                                    @System
libdb.x86_64                                              5.3.28-53.el9                                        @System
libdnf.x86_64                                             0.65.0-5.el9_0                                       @System
libeconf.x86_64                                           0.4.1-2.el9                                          @System
libfdisk.x86_64                                           2.37.4-3.el9                                         @System
libffi.x86_64                                             3.4.2-7.el9                                          @System
libgcc.x86_64                                             11.2.1-9.4.el9                                       @System
libgcrypt.x86_64                                          1.10.0-4.el9_0                                       @System
libgomp.x86_64                                            11.2.1-9.4.el9                                       @System
libgpg-error.x86_64                                       1.42-5.el9                                           @System
libidn2.x86_64                                            2.3.0-7.el9                                          @System
libksba.x86_64                                            1.5.1-4.el9                                          @System
libmodulemd.x86_64                                        2.13.0-2.el9                                         @System
libmount.x86_64                                           2.37.4-3.el9                                         @System
libnghttp2.x86_64                                         1.43.0-5.el9                                         @System
libpsl.x86_64                                             0.21.1-5.el9                                         @System
libpwquality.x86_64                                       1.4.4-8.el9                                          @System
librepo.x86_64                                            1.14.2-1.el9                                         @System
libreport-filesystem.noarch                               2.15.2-6.el9.rocky.0.2                               @System
libseccomp.x86_64                                         2.5.2-2.el9                                          @System
libselinux.x86_64                                         3.3-2.el9                                            @System
libsemanage.x86_64                                        3.3-2.el9                                            @System
libsepol.x86_64                                           3.3-2.el9                                            @System
libsigsegv.x86_64                                         2.13-4.el9                                           @System
libsmartcols.x86_64                                       2.37.4-3.el9                                         @System
libsolv.x86_64                                            0.7.20-2.el9                                         @System
libssh.x86_64                                             0.9.6-3.el9                                          @System
libssh-config.noarch                                      0.9.6-3.el9                                          @System
libstdc++.x86_64                                          11.2.1-9.4.el9                                       @System
libtasn1.x86_64                                           4.16.0-7.el9                                         @System
libunistring.x86_64                                       0.9.10-15.el9                                        @System
libutempter.x86_64                                        1.2.1-6.el9                                          @System
libuuid.x86_64                                            2.37.4-3.el9                                         @System
libverto.x86_64                                           0.3.2-3.el9                                          @System
libxcrypt.x86_64                                          4.4.18-3.el9                                         @System
libxml2.x86_64                                            2.9.13-1.el9_0.1                                     @System
libyaml.x86_64                                            0.2.5-7.el9                                          @System
libzstd.x86_64                                            1.5.1-2.el9                                          @System
lua-libs.x86_64                                           5.4.2-4.el9                                          @System
lz4-libs.x86_64                                           1.9.3-5.el9                                          @System
mpfr.x86_64                                               4.1.0-7.el9                                          @System
ncurses-base.noarch                                       6.2-8.20210508.el9                                   @System
ncurses-libs.x86_64                                       6.2-8.20210508.el9                                   @System
nettle.x86_64                                             3.7.3-2.el9                                          @System
npth.x86_64                                               1.6-8.el9                                            @System
openldap.x86_64                                           2.4.59-4.el9_0                                       @System
openssl.x86_64                                            1:3.0.1-23.el9_0                                     @System
openssl-libs.x86_64                                       1:3.0.1-23.el9_0                                     @System
p11-kit.x86_64                                            0.24.1-2.el9                                         @System
p11-kit-trust.x86_64                                      0.24.1-2.el9                                         @System
pam.x86_64                                                1.5.1-9.el9                                          @System
pcre.x86_64                                               8.44-3.el9.3                                         @System
pcre2.x86_64                                              10.37-5.el9_0                                        @System
pcre2-syntax.noarch                                       10.37-5.el9_0                                        @System
popt.x86_64                                               1.18-8.el9                                           @System
publicsuffix-list-dafsa.noarch                            20210518-3.el9                                       @System
python3.x86_64                                            3.9.10-2.el9                                         @System
python3-dnf.noarch                                        4.10.0-5.el9_0                                       @System
python3-gpg.x86_64                                        1.15.1-6.el9                                         @System
python3-hawkey.x86_64                                     0.65.0-5.el9_0                                       @System
python3-libcomps.x86_64                                   0.1.18-1.el9                                         @System
python3-libdnf.x86_64                                     0.65.0-5.el9_0                                       @System
python3-libs.x86_64                                       3.9.10-2.el9                                         @System
python3-pip-wheel.noarch                                  21.2.3-6.el9                                         @System
python3-rpm.x86_64                                        4.16.1.3-12.el9_0                                    @System
python3-setuptools-wheel.noarch                           53.0.0-10.el9                                        @System
readline.x86_64                                           8.1-4.el9                                            @System
rocky-gpg-keys.noarch                                     9.0-2.1.el9                                          @System
rocky-release.noarch                                      9.0-2.1.el9                                          @System
rocky-repos.noarch                                        9.0-2.1.el9                                          @System
rootfiles.noarch                                          8.1-31.el9                                           @System
rpm.x86_64                                                4.16.1.3-12.el9_0                                    @System
rpm-build-libs.x86_64                                     4.16.1.3-12.el9_0                                    @System
rpm-libs.x86_64                                           4.16.1.3-12.el9_0                                    @System
rpm-sign-libs.x86_64                                      4.16.1.3-12.el9_0                                    @System
sed.x86_64                                                4.8-9.el9                                            @System
setup.noarch                                              2.13.7-6.el9                                         @System
shadow-utils.x86_64                                       2:4.9-3.el9                                          @System
sqlite-libs.x86_64                                        3.34.1-5.el9                                         @System
systemd.x86_64                                            250-6.el9_0                                          @System
systemd-libs.x86_64                                       250-6.el9_0                                          @System
systemd-pam.x86_64                                        250-6.el9_0                                          @System
systemd-rpm-macros.noarch                                 250-6.el9_0                                          @System
tar.x86_64                                                2:1.34-3.el9                                         @System
tpm2-tss.x86_64                                           3.0.3-7.el9                                          @System
tzdata.noarch                                             2022a-1.el9_0                                        @System
util-linux.x86_64                                         2.37.4-3.el9                                         @System
util-linux-core.x86_64                                    2.37.4-3.el9                                         @System
vim-minimal.x86_64                                        2:8.2.2637-16.el9_0.2                                @System
xz-libs.x86_64                                            5.2.5-8.el9_0                                        @System
yum.noarch                                                4.10.0-5.el9_0                                       @System
zlib.x86_64                                               1.2.11-31.el9_0.1                                    @System
```

</details>

<details> <summary>eopkg</summary>

```
~/trouxa$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src silkeh/solus /bin
/bash
root@2cf7abd92da7 /src # ./build/trouxa -m eopkg --dump
INFO[0000] Listing packages
aa-lsm-hook                                 - AppArmor system integration
aalib                                       - AAlib is an portable ascii art GFX library
accountsservice                             - D-Bus service for accessing user accounts and information
acl                                         - Access control list shared library
adwaita-icon-theme                          - The Adwaita Icon Theme package contains an assortment of non-scalable icons of different sizes and themes.
alsa-firmware                               - ALSA Firmware for certain sound cards
alsa-lib                                    - The ALSA Sound Interface
alsa-plugins                                - Plugins for various sound servers
alsa-utils                                  - Various utilities which are useful for controlling your sound card
amtk                                        - Actions, Menus and Toolbars Kit for GTK+ applications
aom                                         - AV1 codec
apparmor                                    - AppArmor LSM user-space component
appstream-data                              - AppStream data for Solus
appstream-glib                              - This library provides objects and helper methods to help reading and writing AppStream metadata.
at-spi2                                     - Accessibility toolkit
at-spi2-atk                                 - Accessibility toolkit - ATK D-Bus Bridge
atkmm                                       - C++ bindings to atk
... (a whole lot of packages hidden for readability)
zlib                                        - zlib (Compression library)
zstd                                        - Zstd command line tools
```

</details>

snap: Couldn't test in my WSL setup due to some compatibility issues, but I believe the command is correct

<details> <summary>yum</summary>

```
~$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src rockylinux:9.0 /bin/bash
[root@8e4c8e557139 src]# ./trouxa/build/trouxa -m yum --dump
INFO[0000] Listing packages
Installed Packages
acl.x86_64                                                 2.3.1-3.el9                                           @System
alternatives.x86_64                                        1.20-2.el9                                            @System
audit-libs.x86_64                                          3.0.7-101.el9_0.2                                     @System
basesystem.noarch                                          11-13.el9                                             @System
bash.x86_64                                                5.1.8-4.el9                                           @System
binutils.x86_64                                            2.35.2-17.el9                                         @System
binutils-gold.x86_64                                       2.35.2-17.el9                                         @System
bzip2-libs.x86_64                                          1.0.8-8.el9                                           @System
ca-certificates.noarch                                     2020.2.50-94.el9                                      @System
coreutils-single.x86_64                                    8.32-31.el9                                           @System
cracklib.x86_64                                            2.9.6-27.el9                                          @System
cracklib-dicts.x86_64                                      2.9.6-27.el9                                          @System
crypto-policies.noarch                                     20220223-1.git5203b41.el9_0.1                         @System
cryptsetup-libs.x86_64                                     2.4.3-4.el9                                           @System
curl.x86_64                                                7.76.1-14.el9_0.4                                     @System
cyrus-sasl-lib.x86_64                                      2.1.27-20.el9                                         @System
dbus.x86_64                                                1:1.12.20-5.el9                                       @System
dbus-broker.x86_64                                         28-5.el9                                              @System
dbus-common.noarch                                         1:1.12.20-5.el9                                       @System
dejavu-sans-fonts.noarch                                   2.37-18.el9                                           @System
device-mapper.x86_64                                       9:1.02.183-4.el9                                      @System
device-mapper-libs.x86_64                                  9:1.02.183-4.el9                                      @System
dnf.noarch                                                 4.10.0-5.el9_0                                        @System
dnf-data.noarch                                            4.10.0-5.el9_0                                        @System
elfutils-debuginfod-client.x86_64                          0.186-1.el9                                           @System
elfutils-default-yama-scope.noarch                         0.186-1.el9                                           @System
elfutils-libelf.x86_64                                     0.186-1.el9                                           @System
elfutils-libs.x86_64                                       0.186-1.el9                                           @System
expat.x86_64                                               2.2.10-12.el9_0.2                                     @System
file-libs.x86_64                                           5.39-8.el9                                            @System
filesystem.x86_64                                          3.16-2.el9                                            @System
fonts-filesystem.noarch                                    1:2.0.5-7.el9.1                                       @System
gawk.x86_64                                                5.1.0-6.el9                                           @System
gdbm-libs.x86_64                                           1:1.19-4.el9                                          @System
glib2.x86_64                                               2.68.4-5.el9                                          @System
glibc.x86_64                                               2.34-28.el9_0                                         @System
glibc-common.x86_64                                        2.34-28.el9_0                                         @System
glibc-minimal-langpack.x86_64                              2.34-28.el9_0                                         @System
gmp.x86_64                                                 1:6.2.0-10.el9                                        @System
gnupg2.x86_64                                              2.3.3-1.el9                                           @System
gnutls.x86_64                                              3.7.3-9.el9                                           @System
gpgme.x86_64                                               1.15.1-6.el9                                          @System
grep.x86_64                                                3.6-5.el9                                             @System
gzip.x86_64                                                1.10-9.el9_0                                          @System
hostname.x86_64                                            3.23-6.el9                                            @System
ima-evm-utils.x86_64                                       1.4-4.el9                                             @System
iputils.x86_64                                             20210202-7.el9                                        @System
json-c.x86_64                                              0.14-11.el9                                           @System
keyutils-libs.x86_64                                       1.6.1-4.el9                                           @System
kmod-libs.x86_64                                           28-7.el9                                              @System
krb5-libs.x86_64                                           1.19.1-15.el9_0                                       @System
langpacks-core-en.noarch                                   3.0-16.el9                                            @System
langpacks-core-font-en.noarch                              3.0-16.el9                                            @System
langpacks-en.noarch                                        3.0-16.el9                                            @System
less.x86_64                                                590-1.el9_0                                           @System
libacl.x86_64                                              2.3.1-3.el9                                           @System
libarchive.x86_64                                          3.5.3-2.el9_0                                         @System
libassuan.x86_64                                           2.5.5-3.el9                                           @System
libattr.x86_64                                             2.5.1-3.el9                                           @System
libblkid.x86_64                                            2.37.4-3.el9                                          @System
libbrotli.x86_64                                           1.0.9-6.el9                                           @System
libcap.x86_64                                              2.48-8.el9                                            @System
libcap-ng.x86_64                                           0.8.2-7.el9                                           @System
libcom_err.x86_64                                          1.46.5-2.el9                                          @System
libcomps.x86_64                                            0.1.18-1.el9                                          @System
libcurl.x86_64                                             7.76.1-14.el9_0.4                                     @System
libdb.x86_64                                               5.3.28-53.el9                                         @System
libdnf.x86_64                                              0.65.0-5.el9_0                                        @System
libeconf.x86_64                                            0.4.1-2.el9                                           @System
libfdisk.x86_64                                            2.37.4-3.el9                                          @System
libffi.x86_64                                              3.4.2-7.el9                                           @System
libgcc.x86_64                                              11.2.1-9.4.el9                                        @System
libgcrypt.x86_64                                           1.10.0-4.el9_0                                        @System
libgomp.x86_64                                             11.2.1-9.4.el9                                        @System
libgpg-error.x86_64                                        1.42-5.el9                                            @System
libidn2.x86_64                                             2.3.0-7.el9                                           @System
libksba.x86_64                                             1.5.1-4.el9                                           @System
libmodulemd.x86_64                                         2.13.0-2.el9                                          @System
libmount.x86_64                                            2.37.4-3.el9                                          @System
libnghttp2.x86_64                                          1.43.0-5.el9                                          @System
libpsl.x86_64                                              0.21.1-5.el9                                          @System
libpwquality.x86_64                                        1.4.4-8.el9                                           @System
librepo.x86_64                                             1.14.2-1.el9                                          @System
libreport-filesystem.noarch                                2.15.2-6.el9.rocky.0.2                                @System
libseccomp.x86_64                                          2.5.2-2.el9                                           @System
libselinux.x86_64                                          3.3-2.el9                                             @System
libsemanage.x86_64                                         3.3-2.el9                                             @System
libsepol.x86_64                                            3.3-2.el9                                             @System
libsigsegv.x86_64                                          2.13-4.el9                                            @System
libsmartcols.x86_64                                        2.37.4-3.el9                                          @System
libsolv.x86_64                                             0.7.20-2.el9                                          @System
libssh.x86_64                                              0.9.6-3.el9                                           @System
libssh-config.noarch                                       0.9.6-3.el9                                           @System
libstdc++.x86_64                                           11.2.1-9.4.el9                                        @System
libtasn1.x86_64                                            4.16.0-7.el9                                          @System
libunistring.x86_64                                        0.9.10-15.el9                                         @System
libutempter.x86_64                                         1.2.1-6.el9                                           @System
libuuid.x86_64                                             2.37.4-3.el9                                          @System
libverto.x86_64                                            0.3.2-3.el9                                           @System
libxcrypt.x86_64                                           4.4.18-3.el9                                          @System
libxml2.x86_64                                             2.9.13-1.el9_0.1                                      @System
libyaml.x86_64                                             0.2.5-7.el9                                           @System
libzstd.x86_64                                             1.5.1-2.el9                                           @System
lua-libs.x86_64                                            5.4.2-4.el9                                           @System
lz4-libs.x86_64                                            1.9.3-5.el9                                           @System
mpfr.x86_64                                                4.1.0-7.el9                                           @System
ncurses-base.noarch                                        6.2-8.20210508.el9                                    @System
ncurses-libs.x86_64                                        6.2-8.20210508.el9                                    @System
nettle.x86_64                                              3.7.3-2.el9                                           @System
npth.x86_64                                                1.6-8.el9                                             @System
openldap.x86_64                                            2.4.59-4.el9_0                                        @System
openssl.x86_64                                             1:3.0.1-23.el9_0                                      @System
openssl-libs.x86_64                                        1:3.0.1-23.el9_0                                      @System
p11-kit.x86_64                                             0.24.1-2.el9                                          @System
p11-kit-trust.x86_64                                       0.24.1-2.el9                                          @System
pam.x86_64                                                 1.5.1-9.el9                                           @System
pcre.x86_64                                                8.44-3.el9.3                                          @System
pcre2.x86_64                                               10.37-5.el9_0                                         @System
pcre2-syntax.noarch                                        10.37-5.el9_0                                         @System
popt.x86_64                                                1.18-8.el9                                            @System
publicsuffix-list-dafsa.noarch                             20210518-3.el9                                        @System
python3.x86_64                                             3.9.10-2.el9                                          @System
python3-dnf.noarch                                         4.10.0-5.el9_0                                        @System
python3-gpg.x86_64                                         1.15.1-6.el9                                          @System
python3-hawkey.x86_64                                      0.65.0-5.el9_0                                        @System
python3-libcomps.x86_64                                    0.1.18-1.el9                                          @System
python3-libdnf.x86_64                                      0.65.0-5.el9_0                                        @System
python3-libs.x86_64                                        3.9.10-2.el9                                          @System
python3-pip-wheel.noarch                                   21.2.3-6.el9                                          @System
python3-rpm.x86_64                                         4.16.1.3-12.el9_0                                     @System
python3-setuptools-wheel.noarch                            53.0.0-10.el9                                         @System
readline.x86_64                                            8.1-4.el9                                             @System
rocky-gpg-keys.noarch                                      9.0-2.1.el9                                           @System
rocky-release.noarch                                       9.0-2.1.el9                                           @System
rocky-repos.noarch                                         9.0-2.1.el9                                           @System
rootfiles.noarch                                           8.1-31.el9                                            @System
rpm.x86_64                                                 4.16.1.3-12.el9_0                                     @System
rpm-build-libs.x86_64                                      4.16.1.3-12.el9_0                                     @System
rpm-libs.x86_64                                            4.16.1.3-12.el9_0                                     @System
rpm-sign-libs.x86_64                                       4.16.1.3-12.el9_0                                     @System
sed.x86_64                                                 4.8-9.el9                                             @System
setup.noarch                                               2.13.7-6.el9                                          @System
shadow-utils.x86_64                                        2:4.9-3.el9                                           @System
sqlite-libs.x86_64                                         3.34.1-5.el9                                          @System
systemd.x86_64                                             250-6.el9_0                                           @System
systemd-libs.x86_64                                        250-6.el9_0                                           @System
systemd-pam.x86_64                                         250-6.el9_0                                           @System
systemd-rpm-macros.noarch                                  250-6.el9_0                                           @System
tar.x86_64                                                 2:1.34-3.el9                                          @System
tpm2-tss.x86_64                                            3.0.3-7.el9                                           @System
tzdata.noarch                                              2022a-1.el9_0                                         @System
util-linux.x86_64                                          2.37.4-3.el9                                          @System
util-linux-core.x86_64                                     2.37.4-3.el9                                          @System
vim-minimal.x86_64                                         2:8.2.2637-16.el9_0.2                                 @System
xz-libs.x86_64                                             5.2.5-8.el9_0                                         @System
yum.noarch                                                 4.10.0-5.el9_0                                        @System
zlib.x86_64                                                1.2.11-31.el9_0.1                                     @System
```

</details>

<details> <summary>zypper</summary>

```
~$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src opensuse/leap:15.3 /bin/ba
sh
Unable to find image 'opensuse/leap:15.3' locally
15.3: Pulling from opensuse/leap
7adeff9765f6: Pull complete
Digest: sha256:2d82069f5fe138904762d6e117709cd6a82754ce4a5db0cca2d86ec745d96468
Status: Downloaded newer image for opensuse/leap:15.3
dea22e49ce76:/src # ./trouxa/build/trouxa -m zypper --dump
INFO[0000] Listing packages
Building repository 'Update repository of openSUSE Backports' cache ..............................................[done]

Note: Received 1 new package signing key from repository "Non-OSS Repository":

  Those additional keys are usually used to sign packages shipped by the repository. In order to
  validate those packages upon download and installation the new keys will be imported into the rpm
  database.

  New:
  Key Fingerprint:  4E98 E675 19D9 8DC7 362A 5990 E3A5 C360 307E 3D54
  Key Name:         SuSE Package Signing Key <build@suse.de>
  Key Algorithm:    RSA 1024
  Key Created:      Thu Mar 15 15:26:29 2018
  Key Expires:      Mon Mar 14 15:26:29 2022 (EXPIRED)
  Rpm Name:         gpg-pubkey-307e3d54-5aaa90a5

  The repository metadata introducing the new keys have been signed and validated by the trusted
  key:

  Repository:       Non-OSS Repository
  Key Fingerprint:  22C0 7BA5 3417 8CD0 2EFE 22AA B88B 2FD4 3DBD C284
  Key Name:         openSUSE Project Signing Key <opensuse@opensuse.org>
  Key Algorithm:    RSA 2048
  Key Created:      Mon May  5 08:37:40 2014
  Key Expires:      Thu May  2 08:37:40 2024
  Rpm Name:         gpg-pubkey-3dbdc284-53674dd4

Building repository 'Non-OSS Repository' cache ...................................................................[done]
Building repository 'Main Repository' cache ......................................................................[done]
Building repository 'Update repository with updates from SUSE Linux Enterprise 15' cache .........................[done]
Building repository 'Main Update Repository' cache ...............................................................[done]
Building repository 'Update Repository (Non-Oss)' cache ..........................................................[done]
Loading repository data...
Reading installed packages...

S  | Name                              | Summary                                                               | Type
---+-----------------------------------+-----------------------------------------------------------------------+--------
i+ | aaa_base                          | openSUSE Base Package                                                 | package
i  | bash                              | The GNU Bourne-Again Shell                                            | package
i  | boost-license1_66_0               | Boost License                                                         | package
i+ | ca-certificates                   | Utilities for system wide CA certificate installation                 | package
i+ | ca-certificates-mozilla           | CA certificates for OpenSSL                                           | package
i  | coreutils                         | GNU Core Utilities                                                    | package
i  | cpio                              | A Backup and Archiving Utility                                        | package
i  | cracklib                          | Library to crack passwords using dictionaries                         | package
i+ | cracklib-dict-small               | Small dictionary for cracklib - A Password-Checking Library           | package
i  | diffutils                         | GNU diff Utilities                                                    | package
i  | file-magic                        | Database for libmagic to help identify files                          | package
i+ | filesystem                        | Basic Directory Layout                                                | package
i  | fillup                            | Tool for Merging Config Files                                         | package
i  | findutils                         | The GNU versions of find utilities (find and xargs)                   | package
i  | gawk                              | GNU awk                                                               | package
i+ | glibc                             | Standard Shared Libraries (from the GNU C Library)                    | package
i  | gpg2                              | File encryption, decryption, signature creation and verification ut-> | package
i  | grep                              | Print lines matching a pattern                                        | package
i  | info                              | A Stand-Alone Terminal-Based Info Browser                             | package
i  | krb5                              | MIT Kerberos5 implementation                                          | package
i+ | kubic-locale-archive              | Minimal locale archive for very small systems                         | package
i+ | Leap                              | openSUSE Leap 15.3                                                    | product
i  | libacl1                           | A dynamic library for accessing POSIX Access Control Lists            | package
i  | libassuan0                        | IPC library used by GnuPG version 2                                   | package
i  | libattr1                          | A dynamic library for filesystem extended attribute support           | package
i  | libaudit1                         | Library for interfacing with the kernel audit subsystem               | package
i  | libaugeas0                        | A library for changing configuration files                            | package
i  | libblkid1                         | Filesystem detection library                                          | package
i  | libboost_system1_66_0             | Boost.System runtime library                                          | package
i  | libboost_thread1_66_0             | Boost.Thread runtime libraries                                        | package
i  | libbz2-1                          | The bzip2 runtime library                                             | package
i  | libcap-ng0                        | An alternate Linux/POSIX capabilities library                         | package
i  | libcap2                           | Library for Capabilities (linux-privs) Support                        | package
i  | libcom_err2                       | E2fsprogs error reporting library                                     | package
i  | libcrack2                         | Library to crack passwords using dictionaries                         | package
i  | libcrypt1                         | Extended crypt library for DES, MD5, Blowfish and others              | package
i  | libcurl4                          | Library for transferring data from URLs                               | package
i  | libdw1                            | Library to access DWARF debugging information                         | package
i  | libebl-plugins                    | Architecture backends for libebl                                      | package
i  | libeconf0                         | Enhanced config file parser ala systemd                               | package
i  | libelf1                           | Library to read and write ELF files                                   | package
i  | libfdisk1                         | Filesystem detection library                                          | package
i  | libffi7                           | Foreign Function Interface Library                                    | package
i  | libgcc_s1                         | C compiler runtime library                                            | package
i  | libgcrypt20                       | The GNU Crypto Library                                                | package
i  | libglib-2_0-0                     | General-Purpose Utility Library                                       | package
i  | libgmp10                          | Shared library for the GNU MP Library                                 | package
i  | libgpg-error0                     | Library That Defines Common Error Values for All GnuPG Components     | package
i  | libgpgme11                        | Programmatic library interface to GnuPG                               | package
i  | libidn2-0                         | Support for Internationalized Domain Names (IDN)                      | package
i  | libkeyutils1                      | Key utilities library                                                 | package
i  | libksba8                          | A X.509 Library                                                       | package
i  | libldap-2_4-2                     | OpenLDAP Client Libraries                                             | package
i  | libldap-data                      | Configuration file for system-wide defaults for all uses of libldap   | package
i  | liblua5_3-5                       | The Lua integration library                                           | package
i  | liblz4-1                          | Hash-based predictive Lempel-Ziv compressor                           | package
i  | liblzma5                          | Lempel–Ziv–Markov chain algorithm compression library                 | package
i  | libmagic1                         | Library for heuristic file type identification                        | package
i  | libmodman1                        | A Module Management Library                                           | package
i  | libmount1                         | Device mount library                                                  | package
i  | libncurses6                       | Terminal control library                                              | package
i  | libnghttp2-14                     | Shared library for nghttp2                                            | package
i  | libnpth0                          | New GNU Portable Threads library                                      | package
i  | libnsl2                           | Network Support Library (NIS/NIS+)                                    | package
i  | libopenssl1_1                     | Secure Sockets and Transport Layer Security                           | package
i  | libp11-kit0                       | Library to work with PKCS#11 modules                                  | package
i  | libpcre1                          | A library for Perl-compatible regular expressions                     | package
i  | libpopt0                          | A C library for parsing command line parameters                       | package
i  | libprocps7                        | The procps library                                                    | package
i  | libprotobuf-lite20                | Protocol Buffers - Google's data interchange format                   | package
i  | libproxy1                         | Automatic proxy configuration management for applications             | package
i  | libpsl5                           | C library for the Publix Suffix List                                  | package
i  | libreadline7                      | The Readline Library                                                  | package
i  | libsasl2-3                        | Simple Authentication and Security Layer (SASL) library               | package
i  | libselinux1                       | SELinux runtime library                                               | package
i  | libsemanage1                      | SELinux policy management library                                     | package
i  | libsepol1                         | SELinux binary policy manipulation library                            | package
i  | libsigc-2_0-0                     | Typesafe Signal Framework for C++                                     | package
i  | libsmartcols1                     | Column-based text sort engine                                         | package
i  | libsolv-tools                     | Utilities to work with .solv files                                    | package
i  | libsqlite3-0                      | Shared libraries for the Embeddable SQL Database Engine               | package
i  | libssh4                           | SSH library                                                           | package
i  | libstdc++6                        | The standard C++ shared library                                       | package
i  | libsystemd0                       | Component library for systemd                                         | package
i  | libtasn1                          | ASN.1 parsing library                                                 | package
i  | libtasn1-6                        | ASN.1 parsing library                                                 | package
i  | libtirpc-netconfig                | Netconfig configuration file for TI-RPC Library                       | package
i  | libtirpc3                         | Transport Independent RPC Library                                     | package
i  | libudev1                          | Dynamic library to access udev device information                     | package
i  | libunistring2                     | GNU Unicode string library                                            | package
i  | libusb-1_0-0                      | USB Library                                                           | package
i  | libutempter0                      | Shared library of utempter                                            | package
i  | libuuid1                          | Library to generate UUIDs                                             | package
i  | libverto1                         | Runtime libraries for libverto                                        | package
i  | libxml2-2                         | A Library to Manipulate XML Files                                     | package
i  | libyaml-cpp0_6                    | YAML parser and emitter in C++                                        | package
i  | libz1                             | Library implementing the DEFLATE compression algorithm                | package
i  | libzio1                           | A Library for Accessing Compressed Text Files                         | package
i  | libzstd1                          | Zstd compression library                                              | package
i  | libzypp                           | Library for package, patch, pattern and product management            | package
i  | login_defs                        | login.defs configuration file                                         | package
i  | ncurses-utils                     | Tools using the new curses libraries                                  | package
i+ | netcfg                            | Network Configuration Files in /etc                                   | package
i  | openssl-1_1                       | Secure Sockets and Transport Layer Security                           | package
i  | openSUSE-2021-820                 | Recommended update for Leap-release                                   | patch
i  | openSUSE-2021-863                 | Recommended update for openSUSE-release                               | patch
i  | openSUSE-2021-1321                | Recommended update for Leap-release                                   | patch
i  | openSUSE-2021-1322                | Recommended update for rpm-repos-openSUSE                             | patch
i  | openSUSE-2021-1457                | Recommended update for openSUSE-Leap-release                          | patch
i  | openSUSE-2021-1464                | Recommended update for openSUSE-Leap-release                          | patch
i  | openSUSE-2021-1520                | Security update for permissions                                       | patch
i  | openSUSE-2021-1576                | Recommended update for permissions                                    | patch
i  | openSUSE-2021-1623                | Recommended update for openSUSE-build-key                             | patch
i  | openSUSE-2022-95                  | Security update for openSUSE-build-key                                | patch
i  | openSUSE-2022-10078               | Recommended update for permissions                                    | patch
i  | openSUSE-2022-10128               | Security update for permissions                                       | patch
i+ | openSUSE-build-key                | The public gpg keys for rpm package signature verification            | package
i+ | openSUSE-release                  | openSUSE Leap 15.3                                                    | package
i+ | openSUSE-release-appliance-docker | openSUSE Leap 15.3                                                    | package
i  | openSUSE-SLE-15.3-2021-1526       | Recommended update for bash                                           | patch
i  | openSUSE-SLE-15.3-2021-1643       | Recommended update for pam                                            | patch
i  | openSUSE-SLE-15.3-2021-1762       | Security update for curl                                              | patch
i  | openSUSE-SLE-15.3-2021-1825       | Security update for lz4                                               | patch
i  | openSUSE-SLE-15.3-2021-1833       | Recommended update for zypper                                         | patch
i  | openSUSE-SLE-15.3-2021-1861       | Recommended update for gcc10                                          | patch
i  | openSUSE-SLE-15.3-2021-1879       | Recommended update for libzypp, zypper                                | patch
i  | openSUSE-SLE-15.3-2021-1917       | Security update for libxml2                                           | patch
i  | openSUSE-SLE-15.3-2021-1937       | Recommended update for nghttp2                                        | patch
i  | openSUSE-SLE-15.3-2021-2157       | Security update for libgcrypt                                         | patch
i  | openSUSE-SLE-15.3-2021-2173       | Recommended update for automake                                       | patch
i  | openSUSE-SLE-15.3-2021-2196       | Security update for lua53                                             | patch
i  | openSUSE-SLE-15.3-2021-2205       | Recommended update for openldap2                                      | patch
i  | openSUSE-SLE-15.3-2021-2273       | Recommended update for libzypp, zypper                                | patch
i  | openSUSE-SLE-15.3-2021-2316       | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2021-2320       | Security update for sqlite3                                           | patch
i  | openSUSE-SLE-15.3-2021-2410       | Security update for systemd                                           | patch
i  | openSUSE-SLE-15.3-2021-2439       | Security update for curl                                              | patch
i  | openSUSE-SLE-15.3-2021-2626       | Recommended maintenance update for libeconf                           | patch
i  | openSUSE-SLE-15.3-2021-2682       | Security update for rpm                                               | patch
i  | openSUSE-SLE-15.3-2021-2763       | Recommended update for cpio                                           | patch
i  | openSUSE-SLE-15.3-2021-2780       | Recommended update for cpio                                           | patch
i  | openSUSE-SLE-15.3-2021-2786       | Recommended update for bash                                           | patch
i  | openSUSE-SLE-15.3-2021-2800       | Security update for krb5                                              | patch
i  | openSUSE-SLE-15.3-2021-2809       | Security update for systemd                                           | patch
i  | openSUSE-SLE-15.3-2021-2830       | Security update for openssl-1_1                                       | patch
i  | openSUSE-SLE-15.3-2021-2938       | Recommended update for openldap2                                      | patch
i  | openSUSE-SLE-15.3-2021-2966       | Security update for openssl-1_1                                       | patch
i  | openSUSE-SLE-15.3-2021-3001       | Recommended update for netcfg                                         | patch
i  | openSUSE-SLE-15.3-2021-3182       | Recommended update for file                                           | patch
i  | openSUSE-SLE-15.3-2021-3274       | Recommended update for ca-certificates-mozilla                        | patch
i  | openSUSE-SLE-15.3-2021-3291       | Security update for glibc                                             | patch
i  | openSUSE-SLE-15.3-2021-3298       | Security update for curl                                              | patch
i  | openSUSE-SLE-15.3-2021-3310       | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2021-3327       | Optional update for coreutils                                         | patch
i  | openSUSE-SLE-15.3-2021-3382       | Recommended update for ca-certificates-mozilla                        | patch
i  | openSUSE-SLE-15.3-2021-3445       | Security update for rpm                                               | patch
i  | openSUSE-SLE-15.3-2021-3454       | Security update for krb5                                              | patch
i  | openSUSE-SLE-15.3-2021-3474       | Security update for util-linux                                        | patch
i  | openSUSE-SLE-15.3-2021-3480       | Recommended update for yast2-network                                  | patch
i  | openSUSE-SLE-15.3-2021-3490       | Security update for ncurses                                           | patch
i  | openSUSE-SLE-15.3-2021-3494       | Recommended update for pam                                            | patch
i  | openSUSE-SLE-15.3-2021-3501       | Recommended update for libzypp, zypper, libsolv, protobuf             | patch
i  | openSUSE-SLE-15.3-2021-3510       | Recommended update for pam                                            | patch
i  | openSUSE-SLE-15.3-2021-3529       | Security update for pcre                                              | patch
i  | openSUSE-SLE-15.3-2021-3564       | Recommended update for rpm-config-SUSE                                | patch
i  | openSUSE-SLE-15.3-2021-3786       | Recommended update for rpm-config-SUSE                                | patch
i  | openSUSE-SLE-15.3-2021-3799       | Recommended update for gcc11                                          | patch
i  | openSUSE-SLE-15.3-2021-3808       | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2021-3870       | Recommended update for libzypp, zypper                                | patch
i  | openSUSE-SLE-15.3-2021-3872       | Recommended update for cracklib                                       | patch
i  | openSUSE-SLE-15.3-2021-3891       | Recommended update for keyutils                                       | patch
i  | openSUSE-SLE-15.3-2021-3899       | Security update for aaa_base                                          | patch
i  | openSUSE-SLE-15.3-2021-3946       | Security update for gmp                                               | patch
i  | openSUSE-SLE-15.3-2021-3963       | Recommended update for system-users                                   | patch
i  | openSUSE-SLE-15.3-2021-3980       | Recommended update for glibc                                          | patch
i  | openSUSE-SLE-15.3-2021-4145       | Recommended update for openssl-1_1                                    | patch
i  | openSUSE-SLE-15.3-2021-4154       | Security update for p11-kit                                           | patch
i  | openSUSE-SLE-15.3-2021-4175       | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2021-4182       | Recommended update for zlib                                           | patch
i  | openSUSE-SLE-15.3-2021-4192       | Security update for permissions                                       | patch
i  | openSUSE-SLE-15.3-2022-4          | Recommended update for libgcrypt                                      | patch
i  | openSUSE-SLE-15.3-2022-43         | Security update for systemd                                           | patch
i  | openSUSE-SLE-15.3-2022-93         | Recommended update for openssl-1_1                                    | patch
i  | openSUSE-SLE-15.3-2022-96         | Recommended update for rpm                                            | patch
i  | openSUSE-SLE-15.3-2022-141        | Security update for permissions                                       | patch
i  | openSUSE-SLE-15.3-2022-207        | Recommended update for glibc                                          | patch
i  | openSUSE-SLE-15.3-2022-228        | Recommended update for boost                                          | patch
i  | openSUSE-SLE-15.3-2022-283        | Security update for samba                                             | patch
i  | openSUSE-SLE-15.3-2022-330        | Security update for glibc                                             | patch
i  | openSUSE-SLE-15.3-2022-335        | Recommended update for coreutils                                      | patch
i  | openSUSE-SLE-15.3-2022-343        | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2022-348        | Recommended update for libzypp                                        | patch
i  | openSUSE-SLE-15.3-2022-383        | Recommended update for cyrus-sasl                                     | patch
i  | openSUSE-SLE-15.3-2022-520        | Recommended update for rpm                                            | patch
i  | openSUSE-SLE-15.3-2022-539        | Security update for systemd                                           | patch
i  | openSUSE-SLE-15.3-2022-674        | Recommended update for yast2-network                                  | patch
i  | openSUSE-SLE-15.3-2022-692        | Recommended update for filesystem                                     | patch
i  | openSUSE-SLE-15.3-2022-727        | Security update for libeconf, shadow and util-linux                   | patch
i  | openSUSE-SLE-15.3-2022-743        | Security update for cyrus-sasl                                        | patch
i  | openSUSE-SLE-15.3-2022-787        | Recommended update for openldap2                                      | patch
i  | openSUSE-SLE-15.3-2022-788        | Recommended update for libzypp, zypper                                | patch
i  | openSUSE-SLE-15.3-2022-789        | Recommended update for update-alternatives                            | patch
i  | openSUSE-SLE-15.3-2022-808        | Recommended update for procps                                         | patch
i  | openSUSE-SLE-15.3-2022-845        | Security update for chrony                                            | patch
i  | openSUSE-SLE-15.3-2022-861        | Security update for openssl-1_1                                       | patch
i  | openSUSE-SLE-15.3-2022-874        | Recommended update for openldap2                                      | patch
i  | openSUSE-SLE-15.3-2022-905        | Recommended update for util-linux                                     | patch
i  | openSUSE-SLE-15.3-2022-936        | Recommended update for filesystem and systemd-rpm-macros              | patch
i  | openSUSE-SLE-15.3-2022-1040       | Security update for protobuf                                          | patch
i  | openSUSE-SLE-15.3-2022-1047       | Recommended update for pam                                            | patch
i  | openSUSE-SLE-15.3-2022-1061       | Security update for zlib                                              | patch
i  | openSUSE-SLE-15.3-2022-1073       | Security update for yaml-cpp                                          | patch
i  | openSUSE-SLE-15.3-2022-1099       | Recommended update for aaa_base                                       | patch
i  | openSUSE-SLE-15.3-2022-1107       | Recommended update for util-linux                                     | patch
i  | openSUSE-SLE-15.3-2022-1157       | Security update for libsolv, libzypp, zypper                          | patch
i  | openSUSE-SLE-15.3-2022-1158       | Security update for xz                                                | patch
i  | openSUSE-SLE-15.3-2022-1170       | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2022-1281       | Recommended update for libtirpc                                       | patch
i  | openSUSE-SLE-15.3-2022-1302       | Recommended update for e2fsprogs                                      | patch
i  | openSUSE-SLE-15.3-2022-1374       | Recommended update for openldap2                                      | patch
i  | openSUSE-SLE-15.3-2022-1409       | Recommended update for gcc11                                          | patch
i  | openSUSE-SLE-15.3-2022-1451       | Recommended update for perl                                           | patch
i  | openSUSE-SLE-15.3-2022-1455       | Security update for glib2                                             | patch
i  | openSUSE-SLE-15.3-2022-1626       | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2022-1655       | Recommended update for pam                                            | patch
i  | openSUSE-SLE-15.3-2022-1657       | Security update for curl                                              | patch
i  | openSUSE-SLE-15.3-2022-1658       | Recommended update for libpsl                                         | patch
i  | openSUSE-SLE-15.3-2022-1670       | Security update for openldap2                                         | patch
i  | openSUSE-SLE-15.3-2022-1688       | Security update for e2fsprogs                                         | patch
i  | openSUSE-SLE-15.3-2022-1691       | Recommended update for augeas                                         | patch
i  | openSUSE-SLE-15.3-2022-1750       | Security update for libxml2                                           | patch
i  | openSUSE-SLE-15.3-2022-1870       | Security update for curl                                              | patch
i  | openSUSE-SLE-15.3-2022-1887       | Recommended update for grep                                           | patch
i  | openSUSE-SLE-15.3-2022-1899       | Recommended update for libtirpc                                       | patch
i  | openSUSE-SLE-15.3-2022-1909       | Recommended update for glibc                                          | patch
i  | openSUSE-SLE-15.3-2022-2019       | Recommended update for gcc11                                          | patch
i  | openSUSE-SLE-15.3-2022-2251       | Security update for openssl-1_1                                       | patch
i  | openSUSE-SLE-15.3-2022-2327       | Security update for curl                                              | patch
i  | openSUSE-SLE-15.3-2022-2328       | Security update for openssl-1_1                                       | patch
i  | openSUSE-SLE-15.3-2022-2361       | Security update for pcre                                              | patch
i  | openSUSE-SLE-15.3-2022-2405       | Security update for p11-kit                                           | patch
i  | openSUSE-SLE-15.3-2022-2406       | Recommended update for glibc                                          | patch
i  | openSUSE-SLE-15.3-2022-2470       | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2022-2494       | Recommended update for glibc                                          | patch
i  | openSUSE-SLE-15.3-2022-2546       | Security update for gpg2                                              | patch
i  | openSUSE-SLE-15.3-2022-2572       | Recommended update for libzypp, zypper                                | patch
i  | openSUSE-SLE-15.3-2022-2614       | Security update for dwarves and elfutils                              | patch
i  | openSUSE-SLE-15.3-2022-2717       | Security update for ncurses                                           | patch
i  | openSUSE-SLE-15.3-2022-2904       | Recommended update for openldap2                                      | patch
i  | openSUSE-SLE-15.3-2022-2921       | Recommended update for systemd                                        | patch
i  | openSUSE-SLE-15.3-2022-2944       | Recommended update for procps                                         | patch
i  | openSUSE-SLE-15.3-2022-2947       | Security update for zlib                                              | patch
i  | openSUSE-SLE-15.3-2022-2982       | Recommended update for util-linux                                     | patch
i  | openSUSE-SLE-15.3-2022-2994       | Recommended update for lame, libass, libcdio-paranoia, libdc1394, l-> | patch
i  | openSUSE-SLE-15.3-2022-3004       | Security update for curl                                              | patch
i  | openSUSE-SLE-15.3-2022-3127       | Recommended update for libtirpc                                       | patch
i  | openSUSE-SLE-15.3-2022-3215       | Recommended update for rpm                                            | patch
i  | openSUSE-SLE-15.3-2022-3223       | Recommended update for libzypp, zypper                                | patch
i  | openSUSE-SLE-15.3-2022-3262       | Recommended update for gcc11                                          | patch
i  | openSUSE-SLE-15.3-2022-3271       | Security update for perl                                              | patch
i  | openSUSE-SLE-15.3-2022-3276       | This update fixes the following issues:                               | patch
i  | openSUSE-SLE-15.3-2022-3304       | Recommended update for libassuan                                      | patch
i  | openSUSE-SLE-15.3-2022-3305       | Security update for libtirpc                                          | patch
i  | openSUSE-SLE-15.3-2022-3307       | Security update for sqlite3                                           | patch
i  | openSUSE-SLE-15.3-2022-3394       | Security update for permissions                                       | patch
i  | openSUSE-SLE-15.3-2022-3395       | Recommended update for ca-certificates-mozilla                        | patch
i  | p11-kit                           | Library to work with PKCS#11 modules                                  | package
i  | p11-kit-tools                     | Library to work with PKCS#11 modules -- Tools                         | package
i  | pam                               | A Security Tool that Provides Authentication for Applications         | package
i  | perl-base                         | The Perl interpreter                                                  | package
i  | permissions                       | SUSE Linux Default Permissions                                        | package
i  | pinentry                          | Collection of Simple PIN or Passphrase Entry Dialogs                  | package
i  | procps                            | The ps utilities for /proc                                            | package
i  | rpm                               | The RPM Package Manager                                               | package
i  | rpm-config-SUSE                   | SUSE specific RPM configuration files                                 | package
i  | sed                               | A Stream-Oriented Non-Interactive Text Editor                         | package
i+ | shadow                            | Utilities to Manage User and Group Accounts                           | package
i  | system-group-hardware             | Hardware related system groups                                        | package
i  | system-user-root                  | System user and group root                                            | package
i  | sysuser-shadow                    | Tool to execute sysusers.d with shadow utilities                      | package
i  | terminfo-base                     | A terminal descriptions database                                      | package
i  | update-alternatives               | Maintain symbolic links determining default commands                  | package
i  | util-linux                        | A collection of basic system utilities                                | package
i+ | zypper                            | Command line software manager using libzypp                           | package
```

</details>

<details> <summary>pacman</summary>

```
~$ docker run --interactive --tty --volume=$(pwd):/src --workdir=/src archlinux /bin/bash
[root@46be40476ff1 src]# pacman -Sy
:: Synchronizing package databases...
 core downloading...
 extra downloading...
 community downloading...
[root@46be40476ff1 src]# pacman -Sy vim jq
:: Synchronizing package databases...
 core downloading...
 extra downloading...
 community downloading...
resolving dependencies...
looking for conflicting packages...

Package (8)          New Version            Net Change  Download Size

core/db              5.3.28-5                 6.41 MiB       1.07 MiB
core/gpm             1.20.7.r38.ge82d1a6-4    0.41 MiB       0.14 MiB
community/oniguruma  6.9.8-1                  0.86 MiB       0.21 MiB
core/pcre            8.45-3                   3.49 MiB       0.97 MiB
core/perl            5.36.0-1                59.79 MiB      15.58 MiB
extra/vim-runtime    9.0.0354-1              33.97 MiB       6.91 MiB
community/jq         1.6-4                    0.67 MiB       0.22 MiB
extra/vim            9.0.0354-1               4.65 MiB       2.08 MiB

Total Download Size:    27.19 MiB
Total Installed Size:  110.24 MiB

:: Proceed with installation? [Y/n] y
:: Retrieving packages...
 perl-5.36.0-1-x86_64 downloading...
 vim-runtime-9.0.0354-1-x86_64 downloading...
 vim-9.0.0354-1-x86_64 downloading...
 db-5.3.28-5-x86_64 downloading...
 pcre-8.45-3-x86_64 downloading...
 jq-1.6-4-x86_64 downloading...
 oniguruma-6.9.8-1-x86_64 downloading...
 gpm-1.20.7.r38.ge82d1a6-4-x86_64 downloading...
checking keyring...
checking package integrity...
loading package files...
checking for file conflicts...
:: Processing package changes...
installing vim-runtime...
Optional dependencies for vim-runtime
    sh: support for some tools and macros [installed]
    python: demoserver example tool
    gawk: mve tools upport [installed]
installing gpm...
installing pcre...
installing db...
installing perl...
installing vim...
Optional dependencies for vim
    python: Python language support
    ruby: Ruby language support
    lua: Lua language support
    tcl: Tcl language support
installing oniguruma...
installing jq...
:: Running post-transaction hooks...
(1/3) Reloading system manager configuration...
  Skipped: Current root is not booted.
(2/3) Arming ConditionNeedsUpdate...
(3/3) Warn about old perl modules
[root@46be40476ff1 src]# ./trouxa/build/trouxa -m pacman --dump
INFO[0000] Listing packages
base 3-1
jq 1.6-4
vim 9.0.0354-1
```

</details>